### PR TITLE
Apply go testing patterns to application layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.3
 	github.com/rs/zerolog v1.34.0
 	github.com/spf13/viper v1.21.0
+	github.com/stretchr/testify v1.11.1
 	go.flipt.io/flipt-client v1.2.0
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0
 	go.opentelemetry.io/otel v1.38.0
@@ -22,6 +23,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cucumber/gherkin/go/v26 v26.2.0 // indirect
 	github.com/cucumber/messages/go/v21 v21.0.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
@@ -36,11 +38,13 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect
 	github.com/tetratelabs/wazero v1.9.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
@@ -53,4 +57,5 @@ require (
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250825161204-c5933d9347a5 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/spf13/viper v1.21.0/go.mod h1:P0lhsswPGWD/1lZJ9ny3fYnVqxiegrlNrEmgLjb
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=

--- a/webserver/pkg/application/evaluate_feature_flag_use_case_test.go
+++ b/webserver/pkg/application/evaluate_feature_flag_use_case_test.go
@@ -1,0 +1,260 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jrb/cuda-learning/webserver/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockFeatureFlagRepository struct {
+	mock.Mock
+}
+
+func (m *mockFeatureFlagRepository) EvaluateBoolean(ctx context.Context, flagKey, entityID string) (*domain.FeatureFlagEvaluation, error) {
+	args := m.Called(ctx, flagKey, entityID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.FeatureFlagEvaluation), args.Error(1)
+}
+
+func (m *mockFeatureFlagRepository) EvaluateVariant(ctx context.Context, flagKey, entityID string) (*domain.FeatureFlagEvaluation, error) {
+	args := m.Called(ctx, flagKey, entityID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.FeatureFlagEvaluation), args.Error(1)
+}
+
+func (m *mockFeatureFlagRepository) SyncFlags(ctx context.Context, flags []domain.FeatureFlag) error {
+	args := m.Called(ctx, flags)
+	return args.Error(0)
+}
+
+func (m *mockFeatureFlagRepository) GetFlag(ctx context.Context, flagKey string) (*domain.FeatureFlag, error) {
+	args := m.Called(ctx, flagKey)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.FeatureFlag), args.Error(1)
+}
+
+func makeValidBooleanEvaluation() *domain.FeatureFlagEvaluation {
+	return &domain.FeatureFlagEvaluation{
+		FlagKey:      "test_flag",
+		EntityID:     "test_entity",
+		Result:       true,
+		Success:      true,
+		UsedFallback: false,
+	}
+}
+
+func makeValidVariantEvaluation() *domain.FeatureFlagEvaluation {
+	return &domain.FeatureFlagEvaluation{
+		FlagKey:      "test_flag",
+		EntityID:     "test_entity",
+		Result:       "variant_value",
+		Success:      true,
+		UsedFallback: false,
+	}
+}
+
+func makeFailedEvaluation() *domain.FeatureFlagEvaluation {
+	return &domain.FeatureFlagEvaluation{
+		FlagKey:      "test_flag",
+		EntityID:     "test_entity",
+		Result:       nil,
+		Success:      false,
+		UsedFallback: true,
+	}
+}
+
+func TestNewEvaluateFeatureFlagUseCase(t *testing.T) {
+	// Arrange
+	repo := new(mockFeatureFlagRepository)
+
+	// Act
+	sut := NewEvaluateFeatureFlagUseCase(repo)
+
+	// Assert
+	require.NotNil(t, sut)
+	assert.Equal(t, repo, sut.repository)
+}
+
+func TestEvaluateFeatureFlagUseCase_EvaluateBoolean(t *testing.T) {
+	var (
+		errRepository = errors.New("repository error")
+	)
+
+	tests := []struct {
+		name         string
+		flagKey      string
+		entityID     string
+		fallbackValue bool
+		mockResult   *domain.FeatureFlagEvaluation
+		mockError    error
+		assertResult func(t *testing.T, result bool, err error)
+	}{
+		{
+			name:         "Success_ValidEvaluation",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: false,
+			mockResult:   makeValidBooleanEvaluation(),
+			mockError:    nil,
+			assertResult: func(t *testing.T, result bool, err error) {
+				assert.NoError(t, err)
+				assert.True(t, result)
+			},
+		},
+		{
+			name:         "Success_RepositoryErrorUsesFallback",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: true,
+			mockResult:   nil,
+			mockError:    errRepository,
+			assertResult: func(t *testing.T, result bool, err error) {
+				assert.NoError(t, err)
+				assert.True(t, result)
+			},
+		},
+		{
+			name:         "Success_EvaluationFailedUsesFallback",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: false,
+			mockResult:   makeFailedEvaluation(),
+			mockError:    nil,
+			assertResult: func(t *testing.T, result bool, err error) {
+				assert.NoError(t, err)
+				assert.False(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mockRepo := new(mockFeatureFlagRepository)
+			mockRepo.On("EvaluateBoolean",
+				mock.Anything,
+				tt.flagKey,
+				tt.entityID,
+			).Return(tt.mockResult, tt.mockError).Once()
+
+			sut := NewEvaluateFeatureFlagUseCase(mockRepo)
+			ctx := context.Background()
+
+			// Act
+			result, err := sut.EvaluateBoolean(ctx, tt.flagKey, tt.entityID, tt.fallbackValue)
+
+			// Assert
+			tt.assertResult(t, result, err)
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEvaluateFeatureFlagUseCase_EvaluateVariant(t *testing.T) {
+	var (
+		errRepository = errors.New("repository error")
+	)
+
+	tests := []struct {
+		name         string
+		flagKey      string
+		entityID     string
+		fallbackValue string
+		mockResult   *domain.FeatureFlagEvaluation
+		mockError    error
+		assertResult func(t *testing.T, result string, err error)
+	}{
+		{
+			name:         "Success_ValidEvaluation",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: "default_variant",
+			mockResult:   makeValidVariantEvaluation(),
+			mockError:    nil,
+			assertResult: func(t *testing.T, result string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "variant_value", result)
+			},
+		},
+		{
+			name:         "Success_RepositoryErrorUsesFallback",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: "fallback_variant",
+			mockResult:   nil,
+			mockError:    errRepository,
+			assertResult: func(t *testing.T, result string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "fallback_variant", result)
+			},
+		},
+		{
+			name:         "Success_EvaluationFailedUsesFallback",
+			flagKey:      "test_flag",
+			entityID:     "test_entity",
+			fallbackValue: "default_variant",
+			mockResult:   makeFailedEvaluation(),
+			mockError:    nil,
+			assertResult: func(t *testing.T, result string, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "default_variant", result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mockRepo := new(mockFeatureFlagRepository)
+			mockRepo.On("EvaluateVariant",
+				mock.Anything,
+				tt.flagKey,
+				tt.entityID,
+			).Return(tt.mockResult, tt.mockError).Once()
+
+			sut := NewEvaluateFeatureFlagUseCase(mockRepo)
+			ctx := context.Background()
+
+			// Act
+			result, err := sut.EvaluateVariant(ctx, tt.flagKey, tt.entityID, tt.fallbackValue)
+
+			// Assert
+			tt.assertResult(t, result, err)
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestEvaluateFeatureFlagUseCase_ContextCancellation(t *testing.T) {
+	// Arrange
+	mockRepo := new(mockFeatureFlagRepository)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockRepo.On("EvaluateBoolean",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(nil, ctx.Err()).Once()
+
+	sut := NewEvaluateFeatureFlagUseCase(mockRepo)
+
+	// Act
+	result, err := sut.EvaluateBoolean(ctx, "test_flag", "test_entity", true)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, result)
+	mockRepo.AssertExpectations(t)
+}

--- a/webserver/pkg/application/get_stream_config_use_case_test.go
+++ b/webserver/pkg/application/get_stream_config_use_case_test.go
@@ -1,0 +1,148 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jrb/cuda-learning/webserver/pkg/config"
+	"github.com/jrb/cuda-learning/webserver/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func makeValidStreamConfig() config.StreamConfig {
+	return config.StreamConfig{
+		TransportFormat:   "json",
+		WebsocketEndpoint: "/ws",
+	}
+}
+
+func makeAlternativeStreamConfig() config.StreamConfig {
+	return config.StreamConfig{
+		TransportFormat:   "protobuf",
+		WebsocketEndpoint: "/ws",
+	}
+}
+
+func TestNewGetStreamConfigUseCase(t *testing.T) {
+	// Arrange
+	mockRepo := new(mockFeatureFlagRepository)
+	evaluateUC := NewEvaluateFeatureFlagUseCase(mockRepo)
+	defaultCfg := makeValidStreamConfig()
+
+	// Act
+	sut := NewGetStreamConfigUseCase(evaluateUC, defaultCfg)
+
+	// Assert
+	require.NotNil(t, sut)
+	assert.Equal(t, evaluateUC, sut.evaluateFFUseCase)
+	assert.Equal(t, defaultCfg, sut.defaultConfig)
+}
+
+func TestGetStreamConfigUseCase_Execute(t *testing.T) {
+	var (
+		errEvaluationFailed = errors.New("evaluation failed")
+	)
+
+	tests := []struct {
+		name           string
+		defaultConfig  config.StreamConfig
+		mockResult     string
+		mockError      error
+		assertResult   func(t *testing.T, result *config.StreamConfig, err error)
+	}{
+		{
+			name:          "Success_DefaultTransportFormat",
+			defaultConfig: makeValidStreamConfig(),
+			mockResult:    "json",
+			mockError:     nil,
+			assertResult: func(t *testing.T, result *config.StreamConfig, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, "json", result.TransportFormat)
+				assert.Equal(t, "/ws", result.WebsocketEndpoint)
+			},
+		},
+		{
+			name:          "Success_AlternativeTransportFormat",
+			defaultConfig: makeValidStreamConfig(),
+			mockResult:    "protobuf",
+			mockError:     nil,
+			assertResult: func(t *testing.T, result *config.StreamConfig, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, "protobuf", result.TransportFormat)
+				assert.Equal(t, "/ws", result.WebsocketEndpoint)
+			},
+		},
+		{
+			name:          "Success_EvaluationFailedUsesFallback",
+			defaultConfig: makeValidStreamConfig(),
+			mockResult:    "",
+			mockError:     errEvaluationFailed,
+			assertResult: func(t *testing.T, result *config.StreamConfig, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, "json", result.TransportFormat)
+				assert.Equal(t, "/ws", result.WebsocketEndpoint)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mockRepo := new(mockFeatureFlagRepository)
+			mockRepo.On("EvaluateVariant",
+				mock.Anything,
+				"ws_transport_format",
+				"stream_transport_format",
+			).Return(&domain.FeatureFlagEvaluation{
+				FlagKey:      "ws_transport_format",
+				EntityID:     "stream_transport_format",
+				Result:       tt.mockResult,
+				Success:      tt.mockError == nil,
+				UsedFallback: false,
+			}, tt.mockError).Once()
+
+			evaluateUC := NewEvaluateFeatureFlagUseCase(mockRepo)
+			sut := NewGetStreamConfigUseCase(evaluateUC, tt.defaultConfig)
+			ctx := context.Background()
+
+			// Act
+			result, err := sut.Execute(ctx)
+
+			// Assert
+			tt.assertResult(t, result, err)
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestGetStreamConfigUseCase_ContextCancellation(t *testing.T) {
+	// Arrange
+	mockRepo := new(mockFeatureFlagRepository)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockRepo.On("EvaluateVariant",
+		mock.Anything,
+		"ws_transport_format",
+		"stream_transport_format",
+	).Return(nil, ctx.Err()).Once()
+
+	evaluateUC := NewEvaluateFeatureFlagUseCase(mockRepo)
+	sut := NewGetStreamConfigUseCase(evaluateUC, makeValidStreamConfig())
+
+	// Act
+	result, err := sut.Execute(ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Equal(t, "json", result.TransportFormat)
+	assert.Equal(t, "/ws", result.WebsocketEndpoint)
+	mockRepo.AssertExpectations(t)
+}

--- a/webserver/pkg/application/list_inputs_use_case_test.go
+++ b/webserver/pkg/application/list_inputs_use_case_test.go
@@ -1,0 +1,76 @@
+package application
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewListInputsUseCase(t *testing.T) {
+	// Arrange & Act
+	sut := NewListInputsUseCase()
+
+	// Assert
+	require.NotNil(t, sut)
+}
+
+func TestListInputsUseCase_Execute(t *testing.T) {
+	tests := []struct {
+		name         string
+		assertResult func(t *testing.T, result []InputSource, err error)
+	}{
+		{
+			name: "Success_ReturnsInputSources",
+			assertResult: func(t *testing.T, result []InputSource, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Len(t, result, 2)
+
+				// Check first source (lena)
+				assert.Equal(t, "lena", result[0].ID)
+				assert.Equal(t, "Lena", result[0].DisplayName)
+				assert.Equal(t, "static", result[0].Type)
+				assert.Equal(t, "/data/lena.png", result[0].ImagePath)
+				assert.True(t, result[0].IsDefault)
+
+				// Check second source (webcam)
+				assert.Equal(t, "webcam", result[1].ID)
+				assert.Equal(t, "Camera", result[1].DisplayName)
+				assert.Equal(t, "camera", result[1].Type)
+				assert.Equal(t, "", result[1].ImagePath)
+				assert.False(t, result[1].IsDefault)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			sut := NewListInputsUseCase()
+			ctx := context.Background()
+
+			// Act
+			result, err := sut.Execute(ctx)
+
+			// Assert
+			tt.assertResult(t, result, err)
+		})
+	}
+}
+
+func TestListInputsUseCase_ContextCancellation(t *testing.T) {
+	// Arrange
+	sut := NewListInputsUseCase()
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// Act
+	result, err := sut.Execute(ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	require.NotNil(t, result)
+	assert.Len(t, result, 2)
+}

--- a/webserver/pkg/application/process_image_use_case_test.go
+++ b/webserver/pkg/application/process_image_use_case_test.go
@@ -1,0 +1,177 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jrb/cuda-learning/webserver/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+type mockImageProcessor struct {
+	mock.Mock
+}
+
+func (m *mockImageProcessor) ProcessImage(ctx context.Context, img *domain.Image, filters []domain.FilterType, accelerator domain.AcceleratorType, grayscaleType domain.GrayscaleType) (*domain.Image, error) {
+	args := m.Called(ctx, img, filters, accelerator, grayscaleType)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*domain.Image), args.Error(1)
+}
+
+func makeValidImage() *domain.Image {
+	return &domain.Image{
+		Data:   []byte{1, 2, 3, 4},
+		Width:  100,
+		Height: 100,
+		Format: "png",
+	}
+}
+
+func makeProcessedImage() *domain.Image {
+	return &domain.Image{
+		Data:   []byte{5, 6, 7, 8},
+		Width:  100,
+		Height: 100,
+		Format: "png",
+	}
+}
+
+func makeValidFilters() []domain.FilterType {
+	return []domain.FilterType{
+		domain.FilterGrayscale,
+	}
+}
+
+func makeEmptyFilters() []domain.FilterType {
+	return []domain.FilterType{}
+}
+
+func TestNewProcessImageUseCase(t *testing.T) {
+	// Arrange
+	processor := new(mockImageProcessor)
+
+	// Act
+	sut := NewProcessImageUseCase(processor)
+
+	// Assert
+	require.NotNil(t, sut)
+	assert.Equal(t, processor, sut.processor)
+}
+
+func TestProcessImageUseCase_Execute(t *testing.T) {
+	var (
+		errProcessingFailed = errors.New("processing failed")
+	)
+
+	tests := []struct {
+		name         string
+		img          *domain.Image
+		filters      []domain.FilterType
+		accelerator  domain.AcceleratorType
+		grayscaleType domain.GrayscaleType
+		mockResult   *domain.Image
+		mockError    error
+		assertResult func(t *testing.T, result *domain.Image, err error)
+	}{
+		{
+			name:          "Success_ValidProcessing",
+			img:           makeValidImage(),
+			filters:       makeValidFilters(),
+			accelerator:   domain.AcceleratorGPU,
+			grayscaleType: domain.GrayscaleBT709,
+			mockResult:    makeProcessedImage(),
+			mockError:     nil,
+			assertResult: func(t *testing.T, result *domain.Image, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, 100, result.Width)
+				assert.Equal(t, 100, result.Height)
+				assert.Equal(t, "png", result.Format)
+				assert.Equal(t, []byte{5, 6, 7, 8}, result.Data)
+			},
+		},
+		{
+			name:          "Success_NoFilters",
+			img:           makeValidImage(),
+			filters:       makeEmptyFilters(),
+			accelerator:   domain.AcceleratorCPU,
+			grayscaleType: domain.GrayscaleAverage,
+			mockResult:    makeProcessedImage(),
+			mockError:     nil,
+			assertResult: func(t *testing.T, result *domain.Image, err error) {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+				assert.Equal(t, 100, result.Width)
+				assert.Equal(t, 100, result.Height)
+			},
+		},
+		{
+			name:          "Error_ProcessingFailed",
+			img:           makeValidImage(),
+			filters:       makeValidFilters(),
+			accelerator:   domain.AcceleratorGPU,
+			grayscaleType: domain.GrayscaleBT709,
+			mockResult:    nil,
+			mockError:     errProcessingFailed,
+			assertResult: func(t *testing.T, result *domain.Image, err error) {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), "failed to process image")
+				assert.Nil(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mockProcessor := new(mockImageProcessor)
+			mockProcessor.On("ProcessImage",
+				mock.Anything,
+				tt.img,
+				tt.filters,
+				tt.accelerator,
+				tt.grayscaleType,
+			).Return(tt.mockResult, tt.mockError).Once()
+
+			sut := NewProcessImageUseCase(mockProcessor)
+			ctx := context.Background()
+
+			// Act
+			result, err := sut.Execute(ctx, tt.img, tt.filters, tt.accelerator, tt.grayscaleType)
+
+			// Assert
+			tt.assertResult(t, result, err)
+			mockProcessor.AssertExpectations(t)
+		})
+	}
+}
+
+func TestProcessImageUseCase_ContextCancellation(t *testing.T) {
+	// Arrange
+	mockProcessor := new(mockImageProcessor)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockProcessor.On("ProcessImage",
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+		mock.Anything,
+	).Return(nil, ctx.Err()).Once()
+
+	sut := NewProcessImageUseCase(mockProcessor)
+
+	// Act
+	result, err := sut.Execute(ctx, makeValidImage(), makeValidFilters(), domain.AcceleratorGPU, domain.GrayscaleBT709)
+
+	// Assert
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	mockProcessor.AssertExpectations(t)
+}

--- a/webserver/pkg/application/sync_feature_flags_use_case_test.go
+++ b/webserver/pkg/application/sync_feature_flags_use_case_test.go
@@ -1,0 +1,127 @@
+package application
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jrb/cuda-learning/webserver/pkg/domain"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func makeValidFeatureFlags() []domain.FeatureFlag {
+	return []domain.FeatureFlag{
+		{
+			Key:          "flag1",
+			Name:         "Test Flag 1",
+			Type:         domain.BooleanFlagType,
+			Enabled:      true,
+			DefaultValue: true,
+		},
+		{
+			Key:          "flag2",
+			Name:         "Test Flag 2",
+			Type:         domain.VariantFlagType,
+			Enabled:      true,
+			DefaultValue: "variant1",
+		},
+	}
+}
+
+func makeEmptyFeatureFlags() []domain.FeatureFlag {
+	return []domain.FeatureFlag{}
+}
+
+func TestNewSyncFeatureFlagsUseCase(t *testing.T) {
+	// Arrange
+	repo := new(mockFeatureFlagRepository)
+
+	// Act
+	sut := NewSyncFeatureFlagsUseCase(repo)
+
+	// Assert
+	require.NotNil(t, sut)
+	assert.Equal(t, repo, sut.repository)
+}
+
+func TestSyncFeatureFlagsUseCase_Execute(t *testing.T) {
+	var (
+		errSyncFailed = errors.New("sync failed")
+	)
+
+	tests := []struct {
+		name         string
+		flags        []domain.FeatureFlag
+		mockError    error
+		assertResult func(t *testing.T, err error)
+	}{
+		{
+			name:      "Success_ValidFlags",
+			flags:     makeValidFeatureFlags(),
+			mockError: nil,
+			assertResult: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:      "Success_EmptyFlags",
+			flags:     makeEmptyFeatureFlags(),
+			mockError: nil,
+			assertResult: func(t *testing.T, err error) {
+				assert.NoError(t, err)
+			},
+		},
+		{
+			name:      "Error_SyncFailed",
+			flags:     makeValidFeatureFlags(),
+			mockError: errSyncFailed,
+			assertResult: func(t *testing.T, err error) {
+				assert.ErrorIs(t, err, errSyncFailed)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange
+			mockRepo := new(mockFeatureFlagRepository)
+			mockRepo.On("SyncFlags",
+				mock.Anything,
+				tt.flags,
+			).Return(tt.mockError).Once()
+
+			sut := NewSyncFeatureFlagsUseCase(mockRepo)
+			ctx := context.Background()
+
+			// Act
+			err := sut.Execute(ctx, tt.flags)
+
+			// Assert
+			tt.assertResult(t, err)
+			mockRepo.AssertExpectations(t)
+		})
+	}
+}
+
+func TestSyncFeatureFlagsUseCase_ContextCancellation(t *testing.T) {
+	// Arrange
+	mockRepo := new(mockFeatureFlagRepository)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	mockRepo.On("SyncFlags",
+		mock.Anything,
+		mock.Anything,
+	).Return(ctx.Err()).Once()
+
+	sut := NewSyncFeatureFlagsUseCase(mockRepo)
+
+	// Act
+	err := sut.Execute(ctx, makeValidFeatureFlags())
+
+	// Assert
+	assert.Error(t, err)
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
Add comprehensive unit tests to the application layer use cases following Go testing best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-e31a9177-2995-4da3-95c5-ea6b163507c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e31a9177-2995-4da3-95c5-ea6b163507c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

