### PR TITLE
feat: Automate Proxmox GitHub runner provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,10 @@ webserver/web/.env.local
 .actrc
 .secrets/git-hub.token
 server
+.docker-cache/
+
+# Terraform artifacts
+**/.terraform/
+**/.terraform.lock.hcl
+**/*.tfstate
+**/*.tfstate.backup

--- a/.secrets/.gitignore
+++ b/.secrets/.gitignore
@@ -9,6 +9,7 @@
 
 # Cloudflare tunnel credentials
 cloudflare/
+keys/
 
 # But keep example files
 !*.example

--- a/scripts/deployment/github-runner/.gitignore
+++ b/scripts/deployment/github-runner/.gitignore
@@ -1,0 +1,1 @@
+proxmox-api.key

--- a/scripts/deployment/github-runner/main.tf
+++ b/scripts/deployment/github-runner/main.tf
@@ -1,0 +1,88 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    proxmox = {
+      source  = "Telmate/proxmox"
+      version = "~> 2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+
+# Run Terraform from a host with API access to Proxmox and an authenticated `gh` CLI session.
+# The file `.secrets/proxmox-api.key` should contain JSON with `token_id` and `token_secret` for the configured Proxmox user.
+# Typical workflow:
+#   terraform init
+#   terraform apply -var='runner_repo=owner/repo' -var='runner_ssh_public_key=ssh-rsa AAA...' -var='pm_lxc_template=storage:vztmpl/template.tar.zst' -var='pm_target_node=pve-node1' -var='pm_rootfs_storage=local-lvm' -var='runner_vm_id=1234'
+
+locals {
+  project_root        = abspath("${path.root}/../../..")
+  secrets_path        = "${local.project_root}/.secrets/proxmox-api.key"
+  proxmox_secret_raw  = try(file(local.secrets_path), null)
+  proxmox_credentials = local.proxmox_secret_raw == null ? null : try(jsondecode(local.proxmox_secret_raw), null)
+
+  pm_api_token_id     = try(coalesce(var.pm_api_token_id, try(local.proxmox_credentials.token_id, null)), null)
+  pm_api_token_secret = try(coalesce(var.pm_api_token_secret, try(local.proxmox_credentials.token_secret, null)), null)
+
+  pm_api_url_clean = replace(replace(var.pm_api_url, "https://", ""), "http://", "")
+  pm_api_host_port = element(split("/", local.pm_api_url_clean), 0)
+  proxmox_host     = element(split(":", local.pm_api_host_port), 0)
+
+  runner_ipv4_address     = element(split("/", var.runner_ipv4_cidr), 0)
+  runner_private_key_path = can(regex("^/", var.runner_ssh_private_key_path)) ? var.runner_ssh_private_key_path : abspath("${local.project_root}/${var.runner_ssh_private_key_path}")
+  runner_label_list       = distinct(compact(concat(["proxmox", "lxc"], var.runner_labels)))
+  runner_label_string     = length(local.runner_label_list) > 0 ? join(",", local.runner_label_list) : ""
+}
+
+provider "proxmox" {
+  pm_api_url          = var.pm_api_url
+  pm_user             = var.pm_user
+  pm_api_token_id     = local.pm_api_token_id
+  pm_api_token_secret = local.pm_api_token_secret
+  pm_tls_insecure     = true
+}
+
+resource "random_password" "runner_root" {
+  length           = 24
+  special          = true
+  override_special = "!#%^*-_"
+}
+
+resource "proxmox_lxc" "runner" {
+  target_node  = var.pm_target_node
+  vmid         = var.runner_vm_id
+  hostname     = var.runner_name
+  ostemplate   = var.pm_lxc_template
+  password     = random_password.runner_root.result
+  start        = true
+  onboot       = true
+  unprivileged = true
+  cores        = var.runner_cores
+  memory       = var.runner_memory
+  swap         = 0
+  ostype       = "ubuntu"
+  description  = "Terraform-managed GitHub Actions runner"
+
+  features {
+    nesting = true
+  }
+
+  rootfs {
+    storage = var.pm_rootfs_storage
+    size    = var.runner_rootfs_size
+  }
+
+  network {
+    name   = "eth0"
+    bridge = var.pm_network_bridge
+    ip     = var.runner_ipv4_cidr
+    gw     = var.runner_ipv4_gateway
+  }
+
+  ssh_public_keys = var.runner_ssh_public_key
+}
+

--- a/scripts/deployment/github-runner/outputs.tf
+++ b/scripts/deployment/github-runner/outputs.tf
@@ -1,0 +1,69 @@
+output "runner_instance_id" {
+  description = "Proxmox VMID of the runner container."
+  value       = proxmox_lxc.runner.id
+}
+
+output "proxmox_host" {
+  description = "Hostname or IP address of the Proxmox node managing the runner."
+  value       = local.proxmox_host
+}
+
+output "runner_ipv4" {
+  description = "IPv4 address assigned to the runner container (without CIDR)."
+  value       = local.runner_ipv4_address
+}
+
+output "runner_ipv4_cidr" {
+  description = "CIDR notation used for the runner container address."
+  value       = var.runner_ipv4_cidr
+}
+
+output "runner_ipv4_gateway" {
+  description = "Gateway configured for the runner container."
+  value       = var.runner_ipv4_gateway
+}
+
+output "runner_private_key_path" {
+  description = "Absolute path to the SSH private key for the runner container."
+  value       = local.runner_private_key_path
+}
+
+output "runner_connection" {
+  description = "Connection parameters for provisioning the runner via Ansible."
+  value = {
+    host             = local.runner_ipv4_address
+    user             = "root"
+    private_key_path = local.runner_private_key_path
+  }
+}
+
+output "runner_template" {
+  description = "Proxmox LXC template identifier used to create the runner."
+  value       = var.pm_lxc_template
+}
+
+output "runner_image_url" {
+  description = "URL for the GitHub Actions runner binary used during provisioning."
+  value       = var.runner_image
+}
+
+output "runner_repo" {
+  description = "GitHub repository bound to this runner."
+  value       = var.runner_repo
+}
+
+output "runner_name" {
+  description = "Logical name assigned to the runner."
+  value       = var.runner_name
+}
+
+output "runner_labels" {
+  description = "Labels that should be applied to the runner."
+  value       = local.runner_label_list
+}
+
+output "runner_labels_csv" {
+  description = "Comma-separated representation of runner labels."
+  value       = local.runner_label_string
+}
+

--- a/scripts/deployment/github-runner/proxmox-api.key.example
+++ b/scripts/deployment/github-runner/proxmox-api.key.example
@@ -1,0 +1,5 @@
+{
+  "token_id": "root@pam!terraform-access",
+  "token_secret": "pm_api_token_secret_goes_here"
+}
+

--- a/scripts/deployment/github-runner/start.sh
+++ b/scripts/deployment/github-runner/start.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+verify_runner_registration() {
+  local repo="$1"
+  local runner="$2"
+  local attempts="${RUNNER_VERIFY_ATTEMPTS:-10}"
+  local delay="${RUNNER_VERIFY_DELAY:-15}"
+
+  echo "Validating runner registration for ${runner} in ${repo}..."
+  for ((attempt = 1; attempt <= attempts; attempt++)); do
+    local status
+    status=$(gh api "repos/${repo}/actions/runners" --paginate --jq ".runners[] | select(.name==\"${runner}\") | .status" || true)
+
+    if [[ -n "${status}" ]]; then
+      echo "Runner '${runner}' reported status: ${status}"
+      if [[ "${status}" == "online" ]]; then
+        echo "Runner '${runner}' is online."
+        return 0
+      fi
+    else
+      echo "Runner '${runner}' not yet registered (attempt ${attempt}/${attempts})."
+    fi
+
+    if [[ ${attempt} -lt ${attempts} ]]; then
+      sleep "${delay}"
+    fi
+  done
+
+  echo "Runner '${runner}' did not register within ${attempts} attempts." >&2
+  return 1
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "${SCRIPT_DIR}"
+
+for cmd in terraform gh ansible-playbook jq python3; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}" >&2
+    echo "Install the tool and rerun this script." >&2
+    exit 1
+  fi
+done
+
+SECRETS_FILE="${PROJECT_ROOT}/.secrets/proxmox-api.key"
+
+if [[ ! -f "${SECRETS_FILE}" ]]; then
+  echo "Missing secrets file: ${SECRETS_FILE}" >&2
+  exit 1
+fi
+
+terraform init -input=false
+terraform apply -input=false -auto-approve "$@"
+
+OUTPUT_JSON_FILE="$(mktemp)"
+ANSIBLE_VARS_FILE="$(mktemp)"
+trap 'rm -f "${OUTPUT_JSON_FILE}" "${ANSIBLE_VARS_FILE}"' EXIT
+
+terraform output -json >"${OUTPUT_JSON_FILE}"
+
+RUNNER_REPO=$(jq -r '.runner_repo.value' "${OUTPUT_JSON_FILE}")
+RUNNER_NAME=$(jq -r '.runner_name.value' "${OUTPUT_JSON_FILE}")
+
+export PROXMOX_SSH_USER="${PROXMOX_SSH_USER:-root}"
+if [[ -z "${PROXMOX_HOST_TASKS_ENABLED:-}" ]]; then
+  if [[ -n "${PROXMOX_SSH_KEY_PATH:-}" ]]; then
+    PROXMOX_HOST_TASKS_ENABLED="true"
+  else
+    PROXMOX_HOST_TASKS_ENABLED="false"
+  fi
+fi
+export PROXMOX_HOST_TASKS_ENABLED
+export PROXMOX_SSH_KEY_PATH="${PROXMOX_SSH_KEY_PATH:-}"
+
+if [[ "${PROXMOX_HOST_TASKS_ENABLED}" != "true" ]]; then
+  echo "Skipping Proxmox host tasks (set PROXMOX_SSH_KEY_PATH to enable)."
+fi
+
+python3 - "${OUTPUT_JSON_FILE}" "${ANSIBLE_VARS_FILE}" <<'PY'
+import json
+import os
+import sys
+
+_, output_path, vars_path = sys.argv
+
+with open(output_path, "r", encoding="utf-8") as fh:
+    outputs = json.load(fh)
+
+def get_value(name):
+    return outputs[name]["value"]
+
+connection = get_value("runner_connection")
+raw_labels = get_value("runner_labels")
+if isinstance(raw_labels, str):
+    runner_labels = [label.strip() for label in raw_labels.split(",") if label.strip()]
+else:
+    runner_labels = list(raw_labels)
+
+vars_payload = {
+    "proxmox_host": get_value("proxmox_host"),
+    "proxmox_user": os.environ.get("PROXMOX_SSH_USER", "root"),
+    "proxmox_private_key_path": os.environ.get("PROXMOX_SSH_KEY_PATH") or None,
+    "proxmox_host_tasks_enabled": os.environ.get("PROXMOX_HOST_TASKS_ENABLED", "false").lower() in ("1", "true", "yes"),
+    "runner_host": connection.get("host"),
+    "runner_user": connection.get("user", "root"),
+    "runner_private_key_path": connection.get("private_key_path"),
+    "runner_repo": get_value("runner_repo"),
+    "runner_name": get_value("runner_name"),
+    "runner_template": get_value("runner_template"),
+    "runner_image_url": get_value("runner_image_url"),
+    "runner_labels": runner_labels,
+    "runner_labels_csv": ",".join(runner_labels),
+    "runner_workdir": "/opt/actions-runner",
+}
+
+with open(vars_path, "w", encoding="utf-8") as fh:
+    json.dump(vars_payload, fh)
+PY
+
+ANSIBLE_DIR="${PROJECT_ROOT}/scripts/deployment/prox4/ansible"
+pushd "${ANSIBLE_DIR}" >/dev/null
+ansible-playbook site.yml -e "@${ANSIBLE_VARS_FILE}"
+popd >/dev/null
+
+verify_runner_registration "${RUNNER_REPO}" "${RUNNER_NAME}"
+

--- a/scripts/deployment/github-runner/stop.sh
+++ b/scripts/deployment/github-runner/stop.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+cd "${SCRIPT_DIR}"
+
+for cmd in terraform gh jq; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "Missing required command: ${cmd}" >&2
+    echo "Install the tool and rerun this script." >&2
+    exit 1
+  fi
+done
+
+SECRETS_FILE="${PROJECT_ROOT}/.secrets/proxmox-api.key"
+if [[ ! -f "${SECRETS_FILE}" ]]; then
+  echo "Missing secrets file: ${SECRETS_FILE}" >&2
+  exit 1
+fi
+
+terraform init -input=false
+
+OUTPUT_JSON_FILE="$(mktemp)"
+trap 'rm -f "${OUTPUT_JSON_FILE}"' EXIT
+
+if terraform output -json >"${OUTPUT_JSON_FILE}"; then
+  RUNNER_REPO=$(jq -r '.runner_repo.value // empty' "${OUTPUT_JSON_FILE}")
+  RUNNER_NAME=$(jq -r '.runner_name.value // empty' "${OUTPUT_JSON_FILE}")
+
+  if [[ -n "${RUNNER_REPO}" && -n "${RUNNER_NAME}" ]]; then
+    echo "Searching for runner '${RUNNER_NAME}' in ${RUNNER_REPO}..."
+    RUNNER_ID=$(gh api "repos/${RUNNER_REPO}/actions/runners" --paginate --jq ".runners[] | select(.name==\"${RUNNER_NAME}\") | .id" || true)
+
+    if [[ -n "${RUNNER_ID}" ]]; then
+      echo "Removing GitHub runner '${RUNNER_NAME}' (ID: ${RUNNER_ID})"
+      gh api "repos/${RUNNER_REPO}/actions/runners/${RUNNER_ID}" --method DELETE >/dev/null
+    else
+      echo "Runner '${RUNNER_NAME}' not found in GitHub; skipping removal."
+    fi
+  fi
+else
+  echo "Unable to read Terraform outputs; skipping GitHub runner removal." >&2
+fi
+
+terraform destroy -input=false -auto-approve "$@"

--- a/scripts/deployment/github-runner/terraform.tfvars
+++ b/scripts/deployment/github-runner/terraform.tfvars
@@ -1,0 +1,14 @@
+pm_api_url        = "https://192.168.10.45:8006/api2/json"
+pm_target_node    = "prox4"
+pm_lxc_template   = "local:vztmpl/debian-12-standard_12.12-1_amd64.tar.zst"
+pm_rootfs_storage = "local-lvm"
+pm_network_bridge = "vmbr0"
+
+runner_vm_id                = 990
+runner_repo                 = "josnelihurt/learning-cuda"
+runner_name                 = "learning-cuda-prox4-x86"
+runner_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPa6IR4wZReEICQYWFTI8+YcLtygFvdjy9511N7Cpb/K github-runner-prox4"
+runner_ssh_private_key_path = ".secrets/keys/github-runner-prox4_ed25519"
+runner_ipv4_cidr            = "192.168.10.90/24"
+runner_ipv4_gateway         = "192.168.10.1"
+

--- a/scripts/deployment/github-runner/variables.tf
+++ b/scripts/deployment/github-runner/variables.tf
@@ -1,0 +1,128 @@
+variable "pm_api_url" {
+  type        = string
+  description = "Proxmox API endpoint (e.g., https://192.168.1.10:8006/api2/json)."
+  default     = "https://192.168.168.10.45:8006/api2/json"
+}
+
+variable "pm_user" {
+  type        = string
+  description = "Proxmox API user with token access."
+  default     = "root@pam"
+}
+
+variable "pm_api_token_id" {
+  type        = string
+  description = "Proxmox API token identifier (user@realm!token-name)."
+  sensitive   = true
+  default     = null
+}
+
+variable "pm_api_token_secret" {
+  type        = string
+  description = "Proxmox API token secret."
+  sensitive   = true
+  default     = null
+}
+
+variable "pm_target_node" {
+  type        = string
+  description = "Target Proxmox node to host the runner container."
+}
+
+variable "pm_lxc_template" {
+  type        = string
+  description = "Proxmox storage/template identifier (e.g., local:vztmpl/debian-12-standard_12.0-1_amd64.tar.zst)."
+}
+
+variable "pm_rootfs_storage" {
+  type        = string
+  description = "Proxmox storage location for the runner root filesystem (e.g., local-lvm)."
+}
+
+variable "pm_network_bridge" {
+  type        = string
+  description = "Network bridge to attach to the LXC container."
+}
+
+variable "runner_repo" {
+  type        = string
+  description = "GitHub repository to bind the self-hosted runner against (owner/name)."
+
+  validation {
+    condition     = can(regex("^[^/]+/[^/]+$", var.runner_repo))
+    error_message = "runner_repo must be provided in the form owner/name."
+  }
+}
+
+variable "runner_labels" {
+  type        = list(string)
+  description = "Extra labels to assign to the self-hosted runner."
+  default     = []
+}
+
+variable "runner_name" {
+  type        = string
+  description = "Static name to assign to the runner."
+}
+
+variable "runner_ssh_public_key" {
+  type        = string
+  description = "SSH public key injected into the runner container for provisioning access."
+
+  validation {
+    condition     = can(regex("^ssh-(rsa|ed25519) ", var.runner_ssh_public_key))
+    error_message = "runner_ssh_public_key must be a valid OpenSSH public key in authorized_keys format."
+  }
+}
+
+variable "runner_ssh_private_key_path" {
+  type        = string
+  description = "Filesystem path to the SSH private key matching runner_ssh_public_key. May be relative to the project root."
+}
+
+variable "runner_image" {
+  type        = string
+  description = "GitHub Actions runner tarball URL."
+  default     = "https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz"
+}
+
+variable "runner_vm_id" {
+  type        = number
+  description = "Unique VMID for the runner LXC container."
+}
+
+variable "runner_memory" {
+  type        = number
+  description = "Memory allocation (MB) for the LXC container."
+  default     = 4096
+}
+
+variable "runner_cores" {
+  type        = number
+  description = "CPU core allocation for the LXC container."
+  default     = 4
+}
+
+variable "runner_rootfs_size" {
+  type        = string
+  description = "Disk size for the runner container rootfs."
+  default     = "40G"
+}
+
+variable "runner_timezone" {
+  type        = string
+  description = "Timezone to configure inside the LXC container."
+  default     = "UTC"
+}
+
+variable "runner_ipv4_cidr" {
+  type        = string
+  description = "IPv4 configuration for the runner container (CIDR or dhcp)."
+}
+
+variable "runner_ipv4_gateway" {
+  type        = string
+  description = "Default gateway for the runner container IPv4 address."
+  default     = null
+}
+

--- a/scripts/deployment/prox4/ansible/ansible.cfg
+++ b/scripts/deployment/prox4/ansible/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+inventory = inventory.yml
+stdout_callback = yaml
+retry_files_enabled = false
+host_key_checking = false

--- a/scripts/deployment/prox4/ansible/inventory.yml
+++ b/scripts/deployment/prox4/ansible/inventory.yml
@@ -1,0 +1,24 @@
+all:
+  vars:
+    runner_workdir: "/opt/actions-runner"
+    runner_image_url: "https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz"
+  children:
+    proxmox:
+      vars:
+        proxmox_host_tasks_enabled: "{{ proxmox_host_tasks_enabled | default(false) }}"
+      hosts:
+        prox4:
+          ansible_host: "{{ proxmox_host }}"
+          ansible_user: "{{ proxmox_user | default('root') }}"
+          ansible_python_interpreter: /usr/bin/python3
+          ansible_ssh_private_key_file: "{{ proxmox_private_key_path | default(omit, true) }}"
+          ansible_ssh_common_args: "{{ proxmox_ssh_common_args | default('-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null') }}"
+          runner_template: "{{ runner_template }}"
+    runner:
+      hosts:
+        github_runner:
+          ansible_host: "{{ runner_host }}"
+          ansible_user: "{{ runner_user | default('root') }}"
+          ansible_python_interpreter: /usr/bin/python3
+          ansible_ssh_private_key_file: "{{ runner_private_key_path }}"
+          ansible_ssh_common_args: "{{ runner_ssh_common_args | default('-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null') }}"

--- a/scripts/deployment/prox4/ansible/site.yml
+++ b/scripts/deployment/prox4/ansible/site.yml
@@ -1,0 +1,171 @@
+---
+- name: Prepare Proxmox host for GitHub runner template
+  hosts: proxmox
+  gather_facts: false
+  become: true
+  vars:
+    runner_template_storage: "{{ runner_template.split(':')[0] }}"
+    runner_template_path: "{{ runner_template.split(':')[1] }}"
+    runner_template_filename: "{{ runner_template_path.split('/')[-1] }}"
+    runner_template_cache_dir: "/var/lib/vz/template/cache"
+    runner_template_cache_path: "{{ runner_template_cache_dir }}/{{ runner_template_filename }}"
+  tasks:
+    - name: Prepare template cache on Proxmox
+      when: proxmox_host_tasks_enabled | bool
+      block:
+        - name: Ensure template cache directory exists
+          ansible.builtin.file:
+            path: "{{ runner_template_cache_dir }}"
+            state: directory
+            mode: "0755"
+
+        - name: Download runner template if missing
+          ansible.builtin.command:
+            cmd: "pveam download {{ runner_template_storage }} {{ runner_template_filename }}"
+            creates: "{{ runner_template_cache_path }}"
+          register: runner_template_download
+          changed_when: runner_template_download.rc == 0
+
+        - name: Display token guidance
+          ansible.builtin.debug:
+            msg:
+              - "Ensure the Proxmox API token configured in .secrets/proxmox-api.key has Administrator privileges."
+              - "Current API endpoint: {{ proxmox_host }}"
+
+    - name: Proxmox host tasks skipped
+      ansible.builtin.debug:
+        msg: "Skipping Proxmox host preparation (set PROXMOX_SSH_KEY_PATH to enable)."
+      when: not (proxmox_host_tasks_enabled | bool)
+
+- name: Configure GitHub Actions runner container
+  hosts: runner
+  gather_facts: false
+  vars:
+    runner_labels_list: >-
+      {% if runner_labels is iterable and runner_labels is not string %}
+      {{ runner_labels | list }}
+      {% elif runner_labels is string %}
+      {{ runner_labels | from_yaml }}
+      {% else %}
+      []
+      {% endif %}
+    runner_labels_csv: "{{ runner_labels_csv | default(runner_labels_list | join(',')) }}"
+    runner_service_name: "actions.runner.{{ runner_repo | replace('/', '-') }}.{{ runner_name }}"
+  tasks:
+    - name: Wait for SSH on runner container
+      become: false
+      ansible.builtin.wait_for:
+        host: "{{ runner_host }}"
+        port: 22
+        state: started
+        timeout: 300
+      delegate_to: localhost
+
+    - name: Install runner dependencies
+      ansible.builtin.apt:
+        name:
+          - curl
+          - jq
+          - tar
+          - git
+          - ca-certificates
+          - apt-transport-https
+          - software-properties-common
+          - docker.io
+        state: present
+        update_cache: true
+
+    - name: Ensure Docker service is enabled
+      ansible.builtin.service:
+        name: docker
+        state: started
+        enabled: true
+
+    - name: Create runner working directory
+      ansible.builtin.file:
+        path: "{{ runner_workdir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+
+    - name: Check existing runner configuration
+      ansible.builtin.stat:
+        path: "{{ runner_workdir }}/.runner"
+      register: runner_state
+
+    - name: Obtain GitHub Actions registration token
+      become: false
+      ansible.builtin.command:
+        cmd: "gh api --method POST repos/{{ runner_repo }}/actions/runners/registration-token --jq .token"
+      delegate_to: localhost
+      register: runner_registration_token
+      changed_when: false
+      when: not runner_state.stat.exists
+
+    - name: Lookup existing runner ID
+      become: false
+      ansible.builtin.command:
+        cmd: >-
+          gh api repos/{{ runner_repo }}/actions/runners --paginate
+          --jq '.runners[] | select(.name == "{{ runner_name }}") | .id'
+      delegate_to: localhost
+      register: runner_existing_id
+      changed_when: false
+
+    - name: Remove existing runner with same name
+      become: false
+      ansible.builtin.command:
+        cmd: "gh api repos/{{ runner_repo }}/actions/runners/{{ runner_existing_id.stdout }} --method DELETE"
+      delegate_to: localhost
+      register: runner_removed
+      changed_when: runner_removed.rc == 0
+      when: runner_existing_id.stdout | length > 0
+
+    - name: Download runner archive
+      ansible.builtin.get_url:
+        url: "{{ runner_image_url }}"
+        dest: "{{ runner_workdir }}/runner.tar.gz"
+        mode: "0644"
+      when: not runner_state.stat.exists
+
+    - name: Extract runner archive
+      ansible.builtin.unarchive:
+        src: "{{ runner_workdir }}/runner.tar.gz"
+        dest: "{{ runner_workdir }}"
+        remote_src: true
+      when: not runner_state.stat.exists
+
+    - name: Configure runner service
+      ansible.builtin.shell: >-
+        ./config.sh --unattended
+        --url https://github.com/{{ runner_repo }}
+        --token {{ runner_registration_token.stdout }}
+        {% if runner_labels_csv %} --labels {{ runner_labels_csv }}{% endif %}
+        --name {{ runner_name }}
+      args:
+        chdir: "{{ runner_workdir }}"
+      environment:
+        RUNNER_ALLOW_RUNASROOT: "1"
+      when: not runner_state.stat.exists
+
+    - name: Install runner service
+      ansible.builtin.command:
+        cmd: "./svc.sh install"
+        chdir: "{{ runner_workdir }}"
+      environment:
+        RUNNER_ALLOW_RUNASROOT: "1"
+      when: not runner_state.stat.exists
+
+    - name: Ensure runner service is running
+      ansible.builtin.command:
+        cmd: "./svc.sh start"
+        chdir: "{{ runner_workdir }}"
+      register: runner_start
+      changed_when: runner_start.rc == 0
+
+    - name: Summarize runner service status
+      ansible.builtin.debug:
+        msg:
+          - "Runner service started: {{ runner_service_name }}"
+          - "Runner labels: {{ runner_labels_csv if runner_labels_csv else 'none' }}"


### PR DESCRIPTION
## Summary
- add Terraform configuration and scripts to provision a GitHub Actions runner inside prox4 using LXC
- introduce prox4 Ansible playbooks and inventory to configure Docker, install the runner, and register it
- add start/stop scripts that manage Terraform, Ansible, and GitHub runner cleanup/verification

## Testing
- /home/jrb/code/cuda-learning/scripts/deployment/github-runner/start.sh
- /home/jrb/code/cuda-learning/scripts/deployment/github-runner/stop.sh

## Related Issues
- Closes #537