### PR TITLE
feat: slim artifact-only intermediate images

### DIFF
--- a/.github/workflows/docker-monorepo-build.yml
+++ b/.github/workflows/docker-monorepo-build.yml
@@ -642,6 +642,7 @@ jobs:
         with:
           context: .
           file: ./cpp_accelerator/Dockerfile.build
+          target: artifacts
           platforms: linux/${{ matrix.arch }}
           build-args: |
             BASE_REGISTRY=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_PREFIX }}
@@ -708,6 +709,7 @@ jobs:
         with:
           context: .
           file: ./webserver/Dockerfile.build
+          target: artifacts
           platforms: linux/${{ matrix.arch }}
           build-args: |
             BASE_REGISTRY=${{ env.REGISTRY }}/${{ env.BASE_IMAGE_PREFIX }}

--- a/cpp_accelerator/Dockerfile.build
+++ b/cpp_accelerator/Dockerfile.build
@@ -90,3 +90,7 @@ RUN VERSION=$(cat cpp_accelerator/VERSION) && \
     mkdir -p /artifacts/lib && \
     cp -L bazel-bin/cpp_accelerator/ports/shared_lib/libcuda_processor.so /artifacts/lib/libcuda_processor_v${VERSION}.so
 
+FROM scratch AS artifacts
+
+COPY --from=cpp-built /artifacts/ /artifacts/
+

--- a/webserver/Dockerfile.build
+++ b/webserver/Dockerfile.build
@@ -28,3 +28,7 @@ RUN make build
 RUN mkdir -p /artifacts/bin && \
     cp ../bin/server /artifacts/bin/
 
+FROM scratch AS artifacts
+
+COPY --from=golang-built /artifacts/ /artifacts/
+


### PR DESCRIPTION
## Summary
- add minimal `scratch` export stages to `cpp_accelerator/Dockerfile.build` and `webserver/Dockerfile.build`
- update `.github/workflows/docker-monorepo-build.yml` to push the new artifact stages via `target: artifacts`
- document work under issue #542 to support the parent roadmap in #536

Closes #542
Related to #536

## Testing
- ./scripts/docker/build.sh --skip-base --arch amd64