### PR TITLE
fix: skip registry login during prepare on prs

### DIFF
--- a/.github/workflows/docker-monorepo-build.yml
+++ b/.github/workflows/docker-monorepo-build.yml
@@ -124,6 +124,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
## Summary
- skip docker login in the prepare job when event is pull_request so manifest checks stay anonymous
- prevents false positives when images are already in ghcr

## Testing
- pending