### PR TITLE
feat: integrate bazel remote cache (#569)

### DIFF
--- a/.github/workflows/docker-monorepo-build-arm.yml
+++ b/.github/workflows/docker-monorepo-build-arm.yml
@@ -491,6 +491,20 @@ jobs:
         if: ${{ steps.gate.outputs.build == 'true' }}
         uses: actions/checkout@v4
 
+      - name: Detect Bazel remote cache
+        if: ${{ steps.gate.outputs.build == 'true' }}
+        shell: bash
+        run: |
+          CACHE_HOST="192.168.10.80"
+          CACHE_STATUS_URL="http://${CACHE_HOST}:9090/status"
+          if curl -sf --connect-timeout 2 --max-time 4 "${CACHE_STATUS_URL}" >/dev/null; then
+            echo "BAZEL_REMOTE_CACHE=grpc://${CACHE_HOST}:9092" >> "$GITHUB_ENV"
+            echo "BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS=true" >> "$GITHUB_ENV"
+            echo "Detected bazel-remote cache at ${CACHE_HOST}"
+          else
+            echo "Bazel-remote cache not reachable; proceeding without remote cache."
+          fi
+
       - name: Log in to GitHub Container Registry
         if: ${{ steps.gate.outputs.build == 'true' && github.event_name != 'pull_request' }}
         uses: docker/login-action@v3

--- a/.github/workflows/docker-monorepo-build-x86.yml
+++ b/.github/workflows/docker-monorepo-build-x86.yml
@@ -272,6 +272,20 @@ jobs:
         if: ${{ steps.gate.outputs.build == 'true' }}
         uses: actions/checkout@v4
 
+      - name: Detect Bazel remote cache
+        if: ${{ steps.gate.outputs.build == 'true' }}
+        shell: bash
+        run: |
+          CACHE_HOST="192.168.10.80"
+          CACHE_STATUS_URL="http://${CACHE_HOST}:9090/status"
+          if curl -sf --connect-timeout 2 --max-time 4 "${CACHE_STATUS_URL}" >/dev/null; then
+            echo "BAZEL_REMOTE_CACHE=grpc://${CACHE_HOST}:9092" >> "$GITHUB_ENV"
+            echo "BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS=true" >> "$GITHUB_ENV"
+            echo "Detected bazel-remote cache at ${CACHE_HOST}"
+          else
+            echo "Bazel-remote cache not reachable; proceeding without remote cache."
+          fi
+
       - name: Log in to GitHub Container Registry
         if: ${{ steps.gate.outputs.build == 'true' && needs.prepare.outputs.can_push == 'true' }}
         uses: docker/login-action@v3

--- a/cpp_accelerator/Dockerfile.build
+++ b/cpp_accelerator/Dockerfile.build
@@ -43,6 +43,9 @@ FROM ${BASE_REGISTRY}/intermediate:proto-generated-${PROTO_VERSION}-${TARGETARCH
 
 FROM bazel-external-deps AS cpp-built
 
+ARG BAZEL_REMOTE_CACHE=""
+ARG BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS="false"
+
 WORKDIR /build
 
 COPY cpp_accelerator/ ./cpp_accelerator/
@@ -57,6 +60,14 @@ RUN echo "Detected TARGETARCH: $TARGETARCH" && \
 
 RUN NPROC=$(cat /tmp/resources.txt | awk '{print $1}') && \
     MEM_GB=$(cat /tmp/resources.txt | awk '{print $2}') && \
+    CACHE_FLAGS="" && \
+    if [ -n "${BAZEL_REMOTE_CACHE}" ]; then \
+        echo "Using remote Bazel cache at ${BAZEL_REMOTE_CACHE}"; \
+        CACHE_FLAGS="${CACHE_FLAGS} --remote_cache=${BAZEL_REMOTE_CACHE} --experimental_remote_downloader=${BAZEL_REMOTE_CACHE}"; \
+        if [ "${BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS}" = "true" ]; then \
+            CACHE_FLAGS="${CACHE_FLAGS} --remote_upload_local_results"; \
+        fi; \
+    fi && \
     if [ "$TARGETARCH" = "arm64" ]; then \
         echo "Building ARM64 with optimized settings (CPUs: $NPROC, RAM: ${MEM_GB}GB)" && \
         bazel build \
@@ -65,7 +76,7 @@ RUN NPROC=$(cat /tmp/resources.txt | awk '{print $1}') && \
           --local_ram_resources=$(($MEM_GB * 1024 * 1024 * 7 / 10)) \
           --local_cpu_resources=$(($NPROC - 1)) \
           --experimental_repository_cache_hardlinks \
-          --disk_cache=/tmp/bazel-cache \
+          --disk_cache=/tmp/bazel-cache ${CACHE_FLAGS} \
           //cpp_accelerator/ports/shared_lib:libcuda_processor.so 2>&1 | tee /tmp/bazel-build.log && \
         echo "ARM64 build completed. Log: $(wc -l < /tmp/bazel-build.log) lines"; \
     else \
@@ -79,7 +90,7 @@ RUN NPROC=$(cat /tmp/resources.txt | awk '{print $1}') && \
           --local_ram_resources=$(($MEM_GB * 1024 * 1024 * 7 / 10)) \
           --local_cpu_resources=$(($NPROC - 1)) \
           --experimental_repository_cache_hardlinks \
-          --disk_cache=/tmp/bazel-cache \
+          --disk_cache=/tmp/bazel-cache ${CACHE_FLAGS} \
           --linkopt="-Wl,--verbose" \
           --linkopt="-Wl,--stats" \
           //cpp_accelerator/ports/shared_lib:libcuda_processor.so 2>&1 | tee /tmp/bazel-build.log && \

--- a/scripts/deployment/github-runner/outputs.tf
+++ b/scripts/deployment/github-runner/outputs.tf
@@ -53,3 +53,13 @@ output "runner_connections" {
   value       = local.runner_connections
 }
 
+output "bazel_cache_details" {
+  description = "Details about the Bazel cache LXC instance."
+  value       = local.bazel_cache_details
+}
+
+output "bazel_cache_connection" {
+  description = "Connection parameters for provisioning the Bazel cache host."
+  value       = local.bazel_cache_connection
+}
+

--- a/scripts/deployment/github-runner/terraform.tfvars
+++ b/scripts/deployment/github-runner/terraform.tfvars
@@ -9,6 +9,16 @@ runner_ssh_public_key       = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIPa6IR4wZReEI
 runner_ssh_private_key_path = ".secrets/keys/github-runner-prox4_ed25519"
 runner_cores                = 8
 
+bazel_cache_instance = {
+  name         = "learning-cuda-prox4-bazel-cache"
+  vm_id        = 980
+  ipv4_cidr    = "192.168.10.80/24"
+  ipv4_gateway = "192.168.10.1"
+  cores        = 4
+  memory       = 8192
+  rootfs_size  = "256G"
+}
+
 runner_instances = [
   {
     name         = "learning-cuda-prox4-x86-1"

--- a/scripts/deployment/github-runner/variables.tf
+++ b/scripts/deployment/github-runner/variables.tf
@@ -105,6 +105,20 @@ variable "runner_image" {
   default     = "https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz"
 }
 
+variable "bazel_cache_instance" {
+  description = "Configuration for the Bazel remote cache LXC container."
+  type = object({
+    name         = string
+    vm_id        = number
+    ipv4_cidr    = string
+    ipv4_gateway = optional(string)
+    cores        = number
+    memory       = number
+    rootfs_size  = string
+  })
+  default = null
+}
+
 variable "runner_instances" {
   description = "Runner instances to provision on Proxmox."
   type = list(object({

--- a/scripts/deployment/prox4/ansible/inventory.yml
+++ b/scripts/deployment/prox4/ansible/inventory.yml
@@ -2,6 +2,17 @@ all:
   vars:
     runner_workdir: "/opt/actions-runner"
     runner_image_url: "https://github.com/actions/runner/releases/download/v2.321.0/actions-runner-linux-x64-2.321.0.tar.gz"
+    bazel_remote_cache_dir: "/var/cache/bazel-remote"
+    bazel_remote_tmp_dir: "/var/cache/bazel-remote-tmp"
+    bazel_remote_bin_path: "/usr/local/bin/bazel-remote"
+    bazel_remote_service_user: "bazelremote"
+    bazel_remote_service_group: "bazelremote"
+    bazel_remote_version: "2.5.2"
+    bazel_remote_http_address: "0.0.0.0"
+    bazel_remote_http_port: 9090
+    bazel_remote_grpc_address: "0.0.0.0:9092"
+    bazel_remote_max_size_gib: 256
+    bazel_remote_arch: "linux-amd64"
   children:
     proxmox:
       vars:
@@ -22,3 +33,11 @@ all:
           ansible_python_interpreter: /usr/bin/python3
           ansible_ssh_private_key_file: "{{ runner_private_key_path }}"
           ansible_ssh_common_args: "{{ runner_ssh_common_args | default('-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null') }}"
+    bazel_cache:
+      hosts:
+        bazel_cache_host:
+          ansible_host: "{{ bazel_cache_host }}"
+          ansible_user: "{{ bazel_cache_user | default('root') }}"
+          ansible_python_interpreter: /usr/bin/python3
+          ansible_ssh_private_key_file: "{{ bazel_cache_private_key_path | default(runner_private_key_path) }}"
+          ansible_ssh_common_args: "{{ bazel_cache_ssh_common_args | default('-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null') }}"

--- a/scripts/deployment/prox4/ansible/site.yml
+++ b/scripts/deployment/prox4/ansible/site.yml
@@ -191,3 +191,133 @@
         msg:
           - "Runner service started: {{ runner_service_name }}"
           - "Runner labels: {{ runner_labels_csv if runner_labels_csv else 'none' }}"
+
+- name: Configure Bazel remote cache host
+  hosts: bazel_cache
+  gather_facts: false
+  become: true
+  vars:
+    bazel_remote_download_url: "https://github.com/buchgr/bazel-remote/releases/download/v{{ bazel_remote_version }}/bazel-remote-{{ bazel_remote_version }}-{{ bazel_remote_arch }}"
+    bazel_remote_flags: [
+      "--dir={{ bazel_remote_cache_dir }}",
+      "--max_size={{ bazel_remote_max_size_gib }}",
+      "--http_address={{ bazel_remote_http_address }}:{{ bazel_remote_http_port }}",
+      "--grpc_address={{ bazel_remote_grpc_address }}",
+    ]
+  tasks:
+    - name: Validate Bazel cache connection variables
+      ansible.builtin.assert:
+        that:
+          - bazel_cache_host is defined
+        fail_msg: "bazel_cache_host must be defined to configure the Bazel cache."
+
+    - name: Wait for SSH on Bazel cache host
+      become: false
+      ansible.builtin.wait_for:
+        host: "{{ bazel_cache_host }}"
+        port: 22
+        state: started
+        timeout: 300
+      delegate_to: localhost
+
+    - name: Install required packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - xz-utils
+        state: present
+        update_cache: true
+
+    - name: Ensure Bazel remote service group exists
+      ansible.builtin.group:
+        name: "{{ bazel_remote_service_group }}"
+        system: true
+
+    - name: Ensure Bazel remote service user exists
+      ansible.builtin.user:
+        name: "{{ bazel_remote_service_user }}"
+        system: true
+        create_home: false
+        group: "{{ bazel_remote_service_group }}"
+
+    - name: Ensure Bazel cache directories exist
+      ansible.builtin.file:
+        path: "{{ item }}"
+        state: directory
+        owner: "{{ bazel_remote_service_user }}"
+        group: "{{ bazel_remote_service_group }}"
+        mode: "0750"
+      loop:
+        - "{{ bazel_remote_cache_dir }}"
+        - "{{ bazel_remote_tmp_dir }}"
+
+    - name: Remove legacy tmp directory inside cache root
+      ansible.builtin.file:
+        path: "{{ bazel_remote_cache_dir }}/tmp"
+        state: absent
+
+    - name: Download bazel-remote binary
+      ansible.builtin.get_url:
+        url: "{{ bazel_remote_download_url }}"
+        dest: "{{ bazel_remote_bin_path }}"
+        owner: root
+        group: root
+        mode: "0755"
+        checksum: "{{ bazel_remote_checksum | default(omit, true) }}"
+
+    - name: Configure systemd service for bazel-remote
+      ansible.builtin.copy:
+        dest: /etc/systemd/system/bazel-remote.service
+        owner: root
+        group: root
+        mode: "0644"
+        content: |
+          [Unit]
+          Description=Bazel Remote Cache
+          After=network-online.target
+          Wants=network-online.target
+
+          [Service]
+          Type=simple
+          User={{ bazel_remote_service_user }}
+          Group={{ bazel_remote_service_group }}
+          ExecStart={{ bazel_remote_bin_path }} {{ bazel_remote_flags | join(' ') }}
+          WorkingDirectory={{ bazel_remote_cache_dir }}
+          Environment=TMPDIR={{ bazel_remote_tmp_dir }}
+          Restart=on-failure
+          RestartSec=5
+          LimitNOFILE=65536
+
+          [Install]
+          WantedBy=multi-user.target
+
+    - name: Reload systemd daemon
+      ansible.builtin.systemd:
+        daemon_reload: true
+
+    - name: Ensure bazel-remote service is enabled and running
+      ansible.builtin.systemd:
+        name: bazel-remote.service
+        state: started
+        enabled: true
+
+    - name: Wait for bazel-remote HTTP port
+      ansible.builtin.wait_for:
+        host: "{{ bazel_cache_host }}"
+        port: "{{ bazel_remote_http_port }}"
+        delay: 2
+        timeout: 60
+      delegate_to: localhost
+      become: false
+
+    - name: Validate bazel-remote status endpoint
+      become: false
+      ansible.builtin.uri:
+        url: "http://{{ bazel_cache_host }}:{{ bazel_remote_http_port }}/status"
+        method: GET
+        status_code: 200
+      register: bazel_remote_status
+      retries: 5
+      delay: 5
+      until: bazel_remote_status.status == 200

--- a/scripts/docker/build-local.sh
+++ b/scripts/docker/build-local.sh
@@ -237,16 +237,26 @@ run_cpp_built() {
   cpp_version="$(read_version "cpp_accelerator/VERSION")"
   local version_tag="${IMAGE_BASE}/intermediate:cpp-built-${cpp_version}-${ARCH}"
   local latest_tag="${IMAGE_BASE}/intermediate:cpp-built-latest-${ARCH}"
+  local build_args=(
+    "--target" "artifacts"
+    "--build-arg" "BASE_REGISTRY=${IMAGE_BASE}"
+    "--build-arg" "BASE_TAG=latest"
+    "--build-arg" "PROTO_VERSION=${proto_version}"
+  )
+
+  if [[ -n "${BAZEL_REMOTE_CACHE:-}" ]]; then
+    build_args+=("--build-arg" "BAZEL_REMOTE_CACHE=${BAZEL_REMOTE_CACHE}")
+    if [[ -n "${BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS:-}" ]]; then
+      build_args+=("--build-arg" "BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS=${BAZEL_REMOTE_UPLOAD_LOCAL_RESULTS}")
+    fi
+  fi
 
   print_stage_header "Building C++ intermediate (${cpp_version})"
   build_and_tag \
     "${version_tag}" \
     "${latest_tag}" \
     "cpp_accelerator/Dockerfile.build" \
-    "--target" "artifacts" \
-    "--build-arg" "BASE_REGISTRY=${IMAGE_BASE}" \
-    "--build-arg" "BASE_TAG=latest" \
-    "--build-arg" "PROTO_VERSION=${proto_version}"
+    "${build_args[@]}"
 }
 
 run_golang_built() {


### PR DESCRIPTION
## Summary
- provision a dedicated bazel-remote cache LXC on prox4 via Terraform/Ansible
- let local docker C++ builds and CI stages opt into the shared cache when reachable
- detect the cache endpoint in GitHub Actions and export the required Bazel flags

Closes #569

## Testing
- ./scripts/docker/build-local.sh --stage cpp
- BAZEL_REMOTE_CACHE=grpc://192.168.10.80:9092 ./scripts/docker/build-local.sh --stage cpp
- git push origin HEAD