### PR TITLE
fix: restore GetProcessorStatus RPC for filter panel (#576)

### DIFF
--- a/proto/config_service.proto
+++ b/proto/config_service.proto
@@ -160,5 +160,12 @@ service ConfigService {
       get: "/api/v1/config/system"
     };
   }
+
+  rpc GetProcessorStatus(GetProcessorStatusRequest) returns (GetProcessorStatusResponse) {
+    option idempotency_level = NO_SIDE_EFFECTS;
+    option (google.api.http) = {
+      get: "/api/v1/config/processor/status"
+    };
+  }
 }
 

--- a/webserver/cmd/server/main.go
+++ b/webserver/cmd/server/main.go
@@ -56,6 +56,7 @@ func main() {
 		app.WithProcessorRegistry(di.ProcessorRegistry),
 		app.WithProcessorLoader(&di.ProcessorLoader),
 		app.WithLoaderMutex(di.LoaderMutex),
+		app.WithCppConnector(di.CppConnector),
 	)
 
 	errChan := make(chan error, 1)

--- a/webserver/pkg/infrastructure/processor/cpp_connector.go
+++ b/webserver/pkg/infrastructure/processor/cpp_connector.go
@@ -196,6 +196,27 @@ func (c *CppConnector) ProcessImage(ctx context.Context, img *domain.Image, filt
 	return result, nil
 }
 
+func (c *CppConnector) GetCapabilities() *pb.LibraryCapabilities {
+	if c.loader != nil {
+		return c.loader.CachedCapabilities()
+	}
+	return nil
+}
+
+func (c *CppConnector) GetAPIVersion() string {
+	if c.loader != nil {
+		return c.loader.GetVersion()
+	}
+	return ""
+}
+
+func (c *CppConnector) GetLibraryVersion() (string, error) {
+	if c.loader != nil {
+		return c.loader.GetLibraryVersion()
+	}
+	return "", fmt.Errorf("loader not available")
+}
+
 func (c *CppConnector) Close() {
 	if c.loader != nil {
 		c.loader.Cleanup()

--- a/webserver/pkg/interfaces/connectrpc/config_handler_test.go
+++ b/webserver/pkg/interfaces/connectrpc/config_handler_test.go
@@ -21,6 +21,7 @@ func TestNewConfigHandler(t *testing.T) {
 		nil, // evaluateFFUseCase
 		nil, // getSystemInfoUseCase
 		mockConfigManager,
+		nil, // cppConnector
 	)
 
 	// Assert

--- a/webserver/pkg/interfaces/connectrpc/server.go
+++ b/webserver/pkg/interfaces/connectrpc/server.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jrb/cuda-learning/proto/gen/genconnect"
 	"github.com/jrb/cuda-learning/webserver/pkg/application"
 	"github.com/jrb/cuda-learning/webserver/pkg/config"
+	"github.com/jrb/cuda-learning/webserver/pkg/infrastructure/processor"
 )
 
 func RegisterRoutes(mux *http.ServeMux, useCase *application.ProcessImageUseCase) {
@@ -33,9 +34,16 @@ func RegisterConfigService(
 	evaluateFFUC *application.EvaluateFeatureFlagUseCase,
 	getSystemInfoUC *application.GetSystemInfoUseCase,
 	configManager *config.Manager,
+	cppConnector interface{},
 	interceptors ...connect.Interceptor,
 ) {
-	configHandler := NewConfigHandler(getStreamConfigUC, syncFlagsUC, listInputsUC, evaluateFFUC, getSystemInfoUC, configManager)
+	var connector *processor.CppConnector
+	if cppConnector != nil {
+		if c, ok := cppConnector.(*processor.CppConnector); ok {
+			connector = c
+		}
+	}
+	configHandler := NewConfigHandler(getStreamConfigUC, syncFlagsUC, listInputsUC, evaluateFFUC, getSystemInfoUC, configManager, connector)
 
 	var opts []connect.HandlerOption
 	if len(interceptors) > 0 {

--- a/webserver/pkg/interfaces/connectrpc/vanguard.go
+++ b/webserver/pkg/interfaces/connectrpc/vanguard.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jrb/cuda-learning/webserver/pkg/application"
 	"github.com/jrb/cuda-learning/webserver/pkg/config"
 	"github.com/jrb/cuda-learning/webserver/pkg/infrastructure/logger"
+	"github.com/jrb/cuda-learning/webserver/pkg/infrastructure/processor"
 	"github.com/jrb/cuda-learning/webserver/pkg/infrastructure/processor/loader"
 )
 
@@ -26,6 +27,7 @@ type VanguardConfig struct {
 	CurrentLoader         **loader.Loader
 	LoaderMutex           *sync.RWMutex
 	ConfigManager         *config.Manager
+	CppConnector          *processor.CppConnector
 	ListAvailableImagesUC *application.ListAvailableImagesUseCase
 	UploadImageUC         *application.UploadImageUseCase
 	ListVideosUC          *application.ListVideosUseCase
@@ -48,7 +50,7 @@ func SetupVanguardTranscoder(cfg *VanguardConfig) http.Handler {
 
 	configHandler := NewConfigHandler(
 		cfg.GetStreamConfigUC, cfg.SyncFlagsUC, cfg.ListInputsUC, cfg.EvaluateFFUC,
-		cfg.GetSystemInfoUC, cfg.ConfigManager,
+		cfg.GetSystemInfoUC, cfg.ConfigManager, cfg.CppConnector,
 	)
 	_, configConnectHandler := genconnect.NewConfigServiceHandler(configHandler, opts...)
 

--- a/webserver/web/src/components/app/app-root.ts
+++ b/webserver/web/src/components/app/app-root.ts
@@ -233,16 +233,33 @@ export class AppRoot extends LitElement {
       this.toastManager.configure({ duration: 7000 });
     }
 
-    if (this.filterManager && this.processorCapabilitiesService?.isInitialized()) {
-      this.filterManager.filters = this.processorCapabilitiesService.getFilters();
-    }
-
-    if (this.toolsDropdown && this.toolsService?.isInitialized()) {
-      this.toolsDropdown.categories = this.toolsService.getCategories();
-    }
+    this.updateFiltersFromService();
+    this.updateToolsFromService();
 
     if (this.videoGrid && this.statsManager && this.toastManager) {
       this.videoGrid.setManagers(this.statsManager, this.toastManager);
+    }
+  }
+
+  private updateFiltersFromService(): void {
+    if (this.filterManager && this.processorCapabilitiesService?.isInitialized()) {
+      this.filterManager.filters = this.processorCapabilitiesService.getFilters();
+    } else if (this.processorCapabilitiesService && !this.processorCapabilitiesService.isInitialized()) {
+      this.processorCapabilitiesService.initialize().then(() => {
+        if (this.filterManager) {
+          this.filterManager.filters = this.processorCapabilitiesService!.getFilters();
+        }
+      }).catch((error) => {
+        this.logger?.error('Failed to initialize processor capabilities', {
+          'error.message': error instanceof Error ? error.message : String(error),
+        });
+      });
+    }
+  }
+
+  private updateToolsFromService(): void {
+    if (this.toolsDropdown && this.toolsService?.isInitialized()) {
+      this.toolsDropdown.categories = this.toolsService.getCategories();
     }
   }
 

--- a/webserver/web/src/gen/config_service_connect.ts
+++ b/webserver/web/src/gen/config_service_connect.ts
@@ -3,7 +3,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { GetAvailableToolsRequest, GetAvailableToolsResponse, GetStreamConfigRequest, GetStreamConfigResponse, GetSystemInfoRequest, GetSystemInfoResponse, ListInputsRequest, ListInputsResponse, SyncFeatureFlagsRequest, SyncFeatureFlagsResponse } from "./config_service_pb.js";
+import { GetAvailableToolsRequest, GetAvailableToolsResponse, GetProcessorStatusRequest, GetProcessorStatusResponse, GetStreamConfigRequest, GetStreamConfigResponse, GetSystemInfoRequest, GetSystemInfoResponse, ListInputsRequest, ListInputsResponse, SyncFeatureFlagsRequest, SyncFeatureFlagsResponse } from "./config_service_pb.js";
 import { MethodIdempotency, MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -58,6 +58,16 @@ export const ConfigService = {
       name: "GetSystemInfo",
       I: GetSystemInfoRequest,
       O: GetSystemInfoResponse,
+      kind: MethodKind.Unary,
+      idempotency: MethodIdempotency.NoSideEffects,
+    },
+    /**
+     * @generated from rpc cuda_learning.ConfigService.GetProcessorStatus
+     */
+    getProcessorStatus: {
+      name: "GetProcessorStatus",
+      I: GetProcessorStatusRequest,
+      O: GetProcessorStatusResponse,
       kind: MethodKind.Unary,
       idempotency: MethodIdempotency.NoSideEffects,
     },

--- a/webserver/web/static/js/dist/.vite/manifest.json
+++ b/webserver/web/static/js/dist/.vite/manifest.json
@@ -1,6 +1,6 @@
 {
   "src/main.ts": {
-    "file": "app.CNIIRjiW.js",
+    "file": "app.ChbCbOuK.js",
     "name": "main",
     "src": "src/main.ts",
     "isEntry": true


### PR DESCRIPTION
## Summary

Restores the `GetProcessorStatus` RPC that was removed during the hot reload refactoring (#574), which caused the frontend filter panel to fail loading filters. The `ProcessorCapabilitiesService` depends on this RPC to fetch filter definitions from the backend.

## Changes

- Restored `GetProcessorStatus` RPC in `ConfigService` proto definition
- Implemented handler in `ConfigHandler` with access to `CppConnector`
- Added `GetCapabilities()`, `GetAPIVersion()`, and `GetLibraryVersion()` methods to `CppConnector`
- Updated service registration to pass `CppConnector` through dependency chain
- Enhanced `app-root` component to handle async filter loading from processor capabilities
- Regenerated proto files (Go and TypeScript)

## Testing

- ✅ Go unit tests pass
- ✅ Frontend unit tests pass
- ✅ Pre-commit hooks pass
- ✅ Pre-push build checks pass
- ✅ Manual verification: `/api/v1/config/processor/status` endpoint returns filter definitions

## Risks

- Low risk: This is a restoration of previously working functionality
- The RPC handler uses existing `CppConnector` methods, no new dependencies
- Frontend changes are minimal and focused on initialization timing

## Related

Closes #576