### PR TITLE
Fix processor gRPC host mismatch

### DIFF
--- a/config/config.production.yaml
+++ b/config/config.production.yaml
@@ -43,7 +43,7 @@ logging:
 
 processor:
   library_base_path: "/app/lib"
-  grpc_server_address: "grpc-server:60061"
+  grpc_server_address: "cuda-grpc-server:60061"
   use_grpc_for_processor: false
 
 static_images:


### PR DESCRIPTION
**Summary**
- point production processor clients at `cuda-grpc-server` to match docker-compose service naming
- avoid failed processor startups caused by mismatched hostnames

**Testing**
- pre-push hook: `bazel build //cpp_accelerator/ports/shared_lib:libcuda_processor.so`
- pre-push hook: go server build
- pre-push hook: frontend Vite build

**Risks**
- low: production-only config change

Closes #587