### PR TITLE
fix: copy ONNX file into Docker build context for ARM64

### DIFF
--- a/.github/workflows/docker-monorepo-build-arm.yml
+++ b/.github/workflows/docker-monorepo-build-arm.yml
@@ -188,18 +188,18 @@ jobs:
           # Create container from scratch image and copy .onnx file
           # Use placeholder command since scratch images have no default
           CONTAINER_ID=$(docker create "${AMD64_IMAGE}" /bin/true)
-          docker cp "${CONTAINER_ID}:/models/yolov10n.onnx" /tmp/yolov10n.onnx
+          docker cp "${CONTAINER_ID}:/models/yolov10n.onnx" src/cpp_accelerator/yolo-model-gen/yolov10n.onnx
           docker rm "${CONTAINER_ID}"
 
           # Build ARM64 yolo-model-gen artifact using the new artifact_from_prebuilt stage
           docker build \
             --platform linux/arm64 \
-            --build-arg "ONNX_FILE=/tmp/yolov10n.onnx" \
+            --build-arg "ONNX_FILE=yolov10n.onnx" \
             --target artifact_from_prebuilt \
             -f src/cpp_accelerator/yolo-model-gen/Dockerfile \
             -t ${REGISTRY}/${BASE_IMAGE_PREFIX}/yolo-model-gen:${YOLO_VERSION}-arm64 \
             -t ${REGISTRY}/${BASE_IMAGE_PREFIX}/yolo-model-gen:latest-arm64 \
-            .
+            src/cpp_accelerator/yolo-model-gen
 
       - name: Push yolo-model-gen image (ARM64)
         if: needs.detect-changes.outputs.yolo_model == 'true' || needs.detect-changes.outputs.cpp_accelerator == 'true'


### PR DESCRIPTION
Dockerfile COPY requires source files to be in the build context.

Changed to:
1. Copy ONNX file to yolo-model-gen directory  
2. Use that directory as build context
3. Reference file with relative path in build arg