### PR TITLE
fix: stop and remove existing containers before deployment

### DIFF
--- a/.github/workflows/docker-monorepo-build-x86.yml
+++ b/.github/workflows/docker-monorepo-build-x86.yml
@@ -443,6 +443,12 @@ jobs:
           cd "${COMPOSE_WORKDIR}"
           export APP_IMAGE CUDA_WEB_FRONTEND_IMAGE
 
+          # Stop and remove existing containers if they exist outside of compose
+          docker ps -q --filter "name=cuda-go-server" | xargs -r docker stop
+          docker ps -q --filter "name=cuda-web-frontend" | xargs -r docker stop
+          docker ps -aq --filter "name=cuda-go-server" | xargs -r docker rm
+          docker ps -aq --filter "name=cuda-web-frontend" | xargs -r docker rm
+
           docker compose up --pull always --force-recreate -d \
             learning-cuda-go-api learning-cuda-frontend
 


### PR DESCRIPTION
## Summary
- Stop cuda-go-server and cuda-web-frontend containers before docker-compose up
- Fixes deployment failure when containers already exist outside of compose
- Ensures clean deployment without container name conflicts

## Test plan
- [x] Tested manually on Vultur - containers successfully recreated
- [x] Verified version logging appears in go-api logs (go_version: 3.0.4, git_commit: dev)
- [ ] CI build passes
- [ ] CI deployment succeeds