### PR TITLE
fix: add libnvinfer_builder_resource.so.10.3.0 mount for YOLO inference

### DIFF
--- a/src/cpp_accelerator/docker-compose.yml
+++ b/src/cpp_accelerator/docker-compose.yml
@@ -29,6 +29,7 @@ services:
       - /usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudla.so.1.0.0:/usr/local/cuda-12.6/targets/aarch64-linux/lib/libcudla.so.1.0.0:ro
       - /usr/lib/aarch64-linux-gnu/libnvinfer.so.10:/usr/lib/aarch64-linux-gnu/libnvinfer.so.10:ro
       - /usr/lib/aarch64-linux-gnu/libnvinfer.so.10.3.0:/usr/lib/aarch64-linux-gnu/libnvinfer.so.10.3.0:ro
+      - /usr/lib/aarch64-linux-gnu/libnvinfer_builder_resource.so.10.3.0:/usr/lib/aarch64-linux-gnu/libnvinfer_builder_resource.so.10.3.0:ro
       - /usr/lib/aarch64-linux-gnu/libnvonnxparser.so.10:/usr/lib/aarch64-linux-gnu/libnvonnxparser.so.10:ro
       - ${ACCELERATOR_MODELS_DIR:-./models}/yolov10n.onnx:/opt/cuda/grpc/data/models/yolov10n.onnx:ro
 


### PR DESCRIPTION
## Summary
- Mount libnvinfer_builder_resource.so.10.3.0 from host to container
- Fixes TensorRT Error Code 6 when loading YOLO v10 model
- Required library for TensorRT 10.3 builder initialization

## Issue
Model inference was failing with:
```
[TRT] createInferBuilder: Error Code 6: API Usage Error (Unable to load library: libnvinfer_builder_resource.so.10.3.0: cannot open shared object file: No such file or directory)
```

## Test plan
- [x] Tested manually on Jetson - model loads successfully
- [x] TRT engine compiled in ~241s (4 minutes)
- [x] YOLO inference now working
- [ ] CI build passes