### PR TITLE
feat: add manual ICE candidate injection for WebRTC public endpoint

### DIFF
--- a/src/cpp_accelerator/docker-compose.yml
+++ b/src/cpp_accelerator/docker-compose.yml
@@ -4,6 +4,10 @@ services:
     container_name: cuda-accelerator-client
     restart: unless-stopped
     runtime: nvidia
+    ports:
+      - "60061:60061/tcp"  # gRPC control
+      - "10000-10199:10000-10199/udp"  # WebRTC ICE candidates
+      - "60062:60062/udp"    # WebRTC fallback UDP
 
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
@@ -12,6 +16,8 @@ services:
       - OTEL_LOGS_ENABLED=false
       - OTEL_LOGS_ENDPOINT=https://otel-cuda-demo.josnelihurt.me/v1/logs
       - OTEL_ENVIRONMENT=production
+      - WEBRTC_PUBLIC_IP=xb19042.gldns.com
+      - WEBRTC_PUBLIC_PORT=60062
 
     command:
       - accelerator_control_client

--- a/src/cpp_accelerator/ports/grpc/webrtc_manager.cpp
+++ b/src/cpp_accelerator/ports/grpc/webrtc_manager.cpp
@@ -265,6 +265,33 @@ bool WebRTCManager::CreateSession(const std::string& session_id, const std::stri
     session->live_filter_state.add_filters(cuda_learning::FILTER_TYPE_NONE);
     session->live_filter_state.set_api_version("1.0");
 
+    // Prepare manual ICE candidate data for SDP modification if configured (before callbacks)
+    // This allows clients behind NAT/firewall to connect using the Jetson's public endpoint
+    const char* public_ip_env = std::getenv("WEBRTC_PUBLIC_IP");
+    const char* public_port_env = std::getenv("WEBRTC_PUBLIC_PORT");
+    std::string manual_candidate_sdp;
+    if (public_ip_env != nullptr && public_port_env != nullptr) {
+      try {
+        const std::string public_ip = public_ip_env;
+        const std::string public_port = public_port_env;
+
+        // SDP candidate format: candidate:foundation component-id transport priority connection-address port typ candidate-type
+        // Example: candidate:1 1 UDP 2130706431 73.71.7.90 60062 typ host
+        std::ostringstream candidate_sdp;
+        candidate_sdp << "a=candidate:1 1 UDP 2130706431 " << public_ip << " " << public_port
+                      << " typ host\r\n";
+        manual_candidate_sdp = candidate_sdp.str();
+
+        spdlog::info("[WebRTC:{}] Will inject manual ICE candidate in SDP: {}:{}",
+                     session_id, public_ip, public_port);
+      } catch (const std::exception& e) {
+        spdlog::warn("[WebRTC:{}] Failed to prepare manual ICE candidate: {}", session_id, e.what());
+      }
+    } else {
+      spdlog::debug("[WebRTC:{}] WEBRTC_PUBLIC_IP or WEBRTC_PUBLIC_PORT not set, skipping manual ICE candidate",
+                    session_id);
+    }
+
     session->peer_connection->onStateChange(
         [session_id, session](rtc::PeerConnection::State state) {
           std::string state_str;
@@ -362,12 +389,38 @@ bool WebRTCManager::CreateSession(const std::string& session_id, const std::stri
     auto answer_promise = std::make_shared<std::promise<std::string>>();
     std::shared_future<std::string> answer_future = answer_promise->get_future();
 
+    // Capture manual_candidate_sdp for the callback by moving it into a shared_ptr
+    auto manual_candidate_ptr = std::make_shared<std::string>(std::move(manual_candidate_sdp));
+
     session->peer_connection->onLocalDescription(
-        [session_id, answer_ptr, answer_promise](rtc::Description description) {
+        [session_id, answer_ptr, answer_promise, manual_candidate_ptr](rtc::Description description) {
           spdlog::info("[WebRTC:{}] Local description created (type: {})", session_id,
                        description.typeString());
           if (description.type() == rtc::Description::Type::Answer) {
             std::string sdp = description.generateSdp();
+
+            // Inject manual ICE candidate into SDP if configured
+            if (!manual_candidate_ptr->empty()) {
+              spdlog::info("[WebRTC:{}] Injecting manual ICE candidate into SDP", session_id);
+              // Find the media section (m=video or m=application) and add candidate after it
+              size_t media_pos = sdp.find("m=");
+              if (media_pos != std::string::npos) {
+                // Find the end of the media block (next m= or end of string)
+                size_t next_media = sdp.find("\r\nm=", media_pos + 2);
+                if (next_media == std::string::npos) {
+                  // Last media section, append at end
+                  next_media = sdp.size();
+                }
+                // Insert candidate before the next media section or at end
+                sdp.insert(next_media, *manual_candidate_ptr);
+                spdlog::info("[WebRTC:{}] Manual ICE candidate injected (SDP length: {} -> {})",
+                             session_id, description.generateSdp().length(), sdp.length());
+              } else {
+                spdlog::warn("[WebRTC:{}] Could not find media section in SDP, candidate not injected",
+                             session_id);
+              }
+            }
+
             if (answer_ptr != nullptr && answer_ptr->empty()) {
               *answer_ptr = sdp;
             }


### PR DESCRIPTION
## Summary
- Add support for manually injecting a public IP/DDNS ICE candidate into the WebRTC SDP answer
- Allows clients behind NAT/firewall to connect to the Jetson accelerator using its public endpoint (xb19042.gldns.com)

## Changes
- Add `WEBRTC_PUBLIC_IP` and `WEBRTC_PUBLIC_PORT` environment variables to docker-compose.yml
- Modify webrtc_manager.cpp to prepare and inject manual ICE candidate into SDP answer when variables are set
- ICE candidate is injected in SDP format: `a=candidate:1 1 UDP 2130706431 <ip> <port> typ host`

## Problem Solved
This solves the issue where corporate firewall blocks client's UDP traffic, preventing P2P WebRTC connection from completing. By providing the Jetson's public IP/DDNS in the SDP answer, clients can establish direct connection.

## Test Plan
- [x] Code compiles successfully with bazel build
- [x] CI passes (x86 build)
- [ ] Deploy to Jetson and validate WebRTC connection from corporate network
- [ ] Verify logs show "Will inject manual ICE candidate in SDP: xb19042.gldns.com:60062"