### PR TITLE
fix: use correct WebRTC UDP port range instead of gRPC port

### DIFF
--- a/src/cpp_accelerator/docker-compose.yml
+++ b/src/cpp_accelerator/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - OTEL_LOGS_ENDPOINT=https://otel-cuda-demo.josnelihurt.me/v1/logs
       - OTEL_ENVIRONMENT=production
       - WEBRTC_PUBLIC_IP=xb19042.gldns.com
-      - WEBRTC_PUBLIC_PORT=60062
+      - WEBRTC_PUBLIC_PORT=10000
 
     command:
       - accelerator_control_client


### PR DESCRIPTION
## Summary
fix: use correct WebRTC UDP port range instead of gRPC port

## Test Plan
- [x] Code compiles successfully
- [x] CI passes
- [x] Deployment validated
