### PR TITLE
fix: use public IP instead of non-existent DDNS for WebRTC

### DIFF
--- a/src/cpp_accelerator/docker-compose.yml
+++ b/src/cpp_accelerator/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - OTEL_LOGS_ENABLED=false
       - OTEL_LOGS_ENDPOINT=https://otel-cuda-demo.josnelihurt.me/v1/logs
       - OTEL_ENVIRONMENT=production
-      - WEBRTC_PUBLIC_IP=xb19042.gldns.com
+      - WEBRTC_PUBLIC_IP=73.71.7.90
       - WEBRTC_PUBLIC_PORT=10000
       - WEBRTC_PUBLIC_TCP_PORT=60060
 


### PR DESCRIPTION
## Summary
fix: use public IP instead of non-existent DDNS for WebRTC

## Test Plan
- [x] Code compiles successfully
- [x] CI passes
- [x] Deployment validated
