### PR TITLE
Refactor Docker image pulling script to support versioned tags

### DIFF
--- a/scripts/docker/pull-ghcr-cpp-intermediates.sh
+++ b/scripts/docker/pull-ghcr-cpp-intermediates.sh
@@ -9,9 +9,13 @@ BASE_IMAGE_PREFIX="${BASE_IMAGE_PREFIX:-josnelihurt-code/learning-cuda}"
 ARCH="${ARCH:-arm64}"
 IMAGE_BASE="${REGISTRY}/${BASE_IMAGE_PREFIX}"
 
+proto_ver="$(tr -d '[:space:]' < "${ROOT}/proto/VERSION")"
+proto_versioned="${IMAGE_BASE}/intermediate:proto-generated-${proto_ver}-${ARCH}"
 proto_latest="${IMAGE_BASE}/intermediate:proto-generated-latest-${ARCH}"
+
 deps_ver="$(tr -d '[:space:]' < "${ROOT}/src/cpp_accelerator/docker-cpp-dependencies/VERSION")"
-deps_img="${IMAGE_BASE}/intermediate:cpp-dependencies-${deps_ver}-${ARCH}"
+deps_versioned="${IMAGE_BASE}/intermediate:cpp-dependencies-${deps_ver}-${ARCH}"
+deps_latest="${IMAGE_BASE}/intermediate:cpp-dependencies-latest-${ARCH}"
 
 pull_if_missing() {
   local ref="$1"
@@ -23,10 +27,23 @@ pull_if_missing() {
   docker pull "${ref}"
 }
 
+# cpp-builder reads the latest tag; cpp-accelerator reads the versioned one.
+# Both point to the same digest on GHCR, but Docker treats them as separate
+# local refs — pull the versioned one and locally retag as latest so every
+# downstream stage finds its input.
+ensure_local_alias() {
+  local from="$1" to="$2"
+  if docker image inspect "${to}" >/dev/null 2>&1; then return 0; fi
+  docker tag "${from}" "${to}"
+  echo "pull-ghcr-cpp-intermediates: tagged ${to} from ${from}"
+}
+
 if [[ "${PULL_PROTO_LATEST:-0}" == "1" ]]; then
-  pull_if_missing "${proto_latest}"
+  pull_if_missing "${proto_versioned}"
+  ensure_local_alias "${proto_versioned}" "${proto_latest}"
 fi
 
 if [[ "${PULL_CPP_DEPENDENCIES:-0}" == "1" ]]; then
-  pull_if_missing "${deps_img}"
+  pull_if_missing "${deps_versioned}"
+  ensure_local_alias "${deps_versioned}" "${deps_latest}"
 fi


### PR DESCRIPTION
- Updated pull-ghcr-cpp-intermediates.sh to pull versioned Docker images for proto and cpp dependencies.
- Introduced ensure_local_alias function to manage local tagging of images, ensuring consistency between versioned and latest tags.
- Enhanced script logic to improve clarity and maintainability in handling Docker image pulls.