### PR TITLE
feat(ci): gate Jetson deploy on src/cpp_accelerator/VERSION bump

### DIFF
--- a/.github/workflows/docker-monorepo-build-arm.yml
+++ b/.github/workflows/docker-monorepo-build-arm.yml
@@ -36,6 +36,7 @@ jobs:
       build_proto: ${{ steps.decide.outputs.build_proto }}
       build_bazel_base: ${{ steps.decide.outputs.build_bazel_base }}
       build_cpp_deps: ${{ steps.decide.outputs.build_cpp_deps }}
+      cpp_version_changed: ${{ steps.decide.outputs.cpp_version_changed }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -64,6 +65,8 @@ jobs:
               - 'WORKSPACE.bazel'
               - '.bazelrc'
               - '.bazelversion'
+            arm_cpp_version:
+              - 'src/cpp_accelerator/VERSION'
             arm_cpp_app:
               - 'src/cpp_accelerator/**/*.cpp'
               - 'src/cpp_accelerator/**/*.h'
@@ -85,16 +88,19 @@ jobs:
           FILTER_ARM_BAZEL_BASE: ${{ steps.filter.outputs.arm_bazel_base }}
           FILTER_ARM_CPP_DEPS: ${{ steps.filter.outputs.arm_cpp_deps }}
           FILTER_ARM_CPP_APP: ${{ steps.filter.outputs.arm_cpp_app }}
+          FILTER_ARM_CPP_VERSION: ${{ steps.filter.outputs.arm_cpp_version }}
         run: |
           set -euo pipefail
           out() { printf '%s\n' "$1" >> "$GITHUB_OUTPUT"; }
 
-          # workflow_dispatch has no diff to filter against; treat as a full rebuild.
+          # workflow_dispatch has no diff to filter against; treat as a full rebuild
+          # and force a redeploy (manual trigger == operator wants the Jetson refreshed).
           if [ "${EVENT_NAME}" = "workflow_dispatch" ]; then
             out "build_proto=true"
             out "build_bazel_base=true"
             out "build_cpp_deps=true"
             out "cpp_touched=true"
+            out "cpp_version_changed=true"
             exit 0
           fi
 
@@ -102,6 +108,7 @@ jobs:
           ab="${FILTER_ARM_BAZEL_BASE:-false}"
           ad="${FILTER_ARM_CPP_DEPS:-false}"
           aa="${FILTER_ARM_CPP_APP:-false}"
+          av="${FILTER_ARM_CPP_VERSION:-false}"
 
           # bazel-base feeds cpp-dependencies, so a bazel-base change forces a deps rebuild too.
           if [ "${ab}" = "true" ]; then ad="true"; fi
@@ -109,6 +116,7 @@ jobs:
           out "build_proto=${ap}"
           out "build_bazel_base=${ab}"
           out "build_cpp_deps=${ad}"
+          out "cpp_version_changed=${av}"
           if [ "${ap}" = "true" ] || [ "${ab}" = "true" ] || [ "${ad}" = "true" ] || [ "${aa}" = "true" ]; then
             out "cpp_touched=true"
           else
@@ -176,9 +184,13 @@ jobs:
   deploy_prod:
     name: Deploy production (Jetson Nano)
     needs:
+      - detect-changes
       - build_and_push
     runs-on: ["self-hosted", "Linux", "ARM64"]
-    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
+    # Only redeploy the Jetson when src/cpp_accelerator/VERSION actually bumped.
+    # A push that only touches deps/proto/app rebuilds the image but keeps the
+    # same versioned tag, so the running container is already the right code.
+    if: ${{ ((github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch') && needs.detect-changes.outputs.cpp_version_changed == 'true' }}
     steps:
       - name: Validate Jetson vars and secrets
         env:

--- a/src/cpp_accelerator/ports/grpc/main_client.cpp
+++ b/src/cpp_accelerator/ports/grpc/main_client.cpp
@@ -20,8 +20,7 @@ ABSL_FLAG(std::string, control_addr, "localhost:60062",
           "Address of the Go cloud control server (host:port).");
 ABSL_FLAG(std::string, device_id, "dev-accelerator",
           "Stable device identifier sent during registration.");
-ABSL_FLAG(std::string, display_name, "Dev Accelerator",
-          "Human-readable name shown in the UI.");
+ABSL_FLAG(std::string, display_name, "Dev Accelerator", "Human-readable name shown in the UI.");
 ABSL_FLAG(int, cuda_device_id, 0, "CUDA device ID to initialize on startup.");
 ABSL_FLAG(int, max_message_mb, 64, "Maximum gRPC message size in MiB.");
 ABSL_FLAG(std::string, client_cert, ".secrets/dev-accelerator-client.pem",
@@ -30,9 +29,9 @@ ABSL_FLAG(std::string, client_key, ".secrets/dev-accelerator-client-key.pem",
           "Path to client TLS private key (PEM).");
 ABSL_FLAG(std::string, ca_cert, ".secrets/accelerator-ca.pem",
           "Path to CA certificate used to verify the server (PEM).");
-ABSL_FLAG(int, max_reconnect_delay_s, 60,
-          "Maximum reconnect back-off in seconds.");
+ABSL_FLAG(int, max_reconnect_delay_s, 60, "Maximum reconnect back-off in seconds.");
 
+// This is the main entry point for the accelerator control client.
 int main(int argc, char** argv) {
   absl::ParseCommandLine(argc, argv);
 
@@ -64,24 +63,22 @@ int main(int argc, char** argv) {
   }
 
   jrb::ports::grpc_service::AcceleratorControlClientConfig cfg;
-  cfg.control_addr          = absl::GetFlag(FLAGS_control_addr);
-  cfg.device_id             = absl::GetFlag(FLAGS_device_id);
-  cfg.display_name          = absl::GetFlag(FLAGS_display_name);
-  cfg.accelerator_version   = LIBRARY_VERSION_STR;
-  cfg.client_cert_file      = absl::GetFlag(FLAGS_client_cert);
-  cfg.client_key_file       = absl::GetFlag(FLAGS_client_key);
-  cfg.ca_cert_file          = absl::GetFlag(FLAGS_ca_cert);
+  cfg.control_addr = absl::GetFlag(FLAGS_control_addr);
+  cfg.device_id = absl::GetFlag(FLAGS_device_id);
+  cfg.display_name = absl::GetFlag(FLAGS_display_name);
+  cfg.accelerator_version = LIBRARY_VERSION_STR;
+  cfg.client_cert_file = absl::GetFlag(FLAGS_client_cert);
+  cfg.client_key_file = absl::GetFlag(FLAGS_client_key);
+  cfg.ca_cert_file = absl::GetFlag(FLAGS_ca_cert);
   cfg.max_reconnect_delay_s = absl::GetFlag(FLAGS_max_reconnect_delay_s);
 
   jrb::ports::grpc_service::AcceleratorControlClient client(cfg, adapter, webrtc_manager);
 
   auto& signal_handler = jrb::core::SignalHandler::GetInstance();
-  signal_handler.Initialize(
-    [&client]() {
-      spdlog::warn("Shutdown signal received — stopping accelerator client");
-      client.Stop();
-    }
-  );
+  signal_handler.Initialize([&client]() {
+    spdlog::warn("Shutdown signal received — stopping accelerator client");
+    client.Stop();
+  });
 
   client.Run();
 


### PR DESCRIPTION
deploy_prod now runs only when src/cpp_accelerator/VERSION actually changed (or on workflow_dispatch). A push that only touches deps, proto, or app code rebuilds and pushes the cpp-accelerator image but under the same versioned tag — the running container is already on the right code, so redeploying the Jetson would be a no-op restart.

detect-changes gains a new arm_cpp_version path filter and emits a cpp_version_changed output that gates the deploy_prod job.