### PR TITLE
docs: expand README files for OpenCL and Vulkan examples

### DIFF
--- a/src/cpp_accelerator/cmd/hello-world-opencl/README.md
+++ b/src/cpp_accelerator/cmd/hello-world-opencl/README.md
@@ -3,6 +3,274 @@
 Minimal OpenCL example: add two float vectors on the GPU and verify the result.
 This sample uses embedded shader assets generated at build time.
 
+## What is OpenCL?
+
+OpenCL (Open Computing Language) is an open, royalty-free standard for
+heterogeneous parallel computing. It was created by the Khronos Group and first
+released as OpenCL 1.0 in 2009. The current specification is OpenCL 3.0.
+
+OpenCL lets you write programs that execute across CPUs, GPUs, DSPs, FPGAs, and
+other accelerators. Unlike CUDA, it is not tied to a single vendor — code
+written against the OpenCL API can run on hardware from NVIDIA, AMD, Intel,
+ARM, Qualcomm, and others.
+
+Key versions:
+
+| Version | Year | Highlights |
+|---------|------|------------|
+| 1.0 | 2009 | Initial release, C-based kernel language |
+| 1.2 | 2011 | Device partitioning, separate compilation |
+| 2.0 | 2013 | Shared virtual memory, dynamic parallelism, C++ kernel language |
+| 2.2 | 2017 | SPIR-V as intermediate language |
+| 3.0 | 2020 | Optional features model, backwards-compatible with 1.2 |
+
+## Core Concepts You Need to Know
+
+### The Platform Model
+
+OpenCL organizes the hardware into a hierarchy:
+
+- **Platform** — A vendor's OpenCL implementation (ICD — Installable Client
+  Driver). A system can have multiple platforms (e.g., one from NVIDIA, one from
+  Intel). You enumerate them with `clGetPlatformIDs`.
+- **Device** — A compute unit within a platform. A platform may expose multiple
+  devices (e.g., a GPU and a CPU). Devices have types: `CL_DEVICE_TYPE_GPU`,
+  `CL_DEVICE_TYPE_CPU`, `CL_DEVICE_TYPE_ACCELERATOR`, etc.
+- **Context** — An execution environment that groups devices, memory objects,
+  and command queues. Created with `clCreateContext`.
+- **Command Queue** — A queue that holds commands (kernel launches, memory
+  transfers) submitted to a specific device. Created with
+  `clCreateCommandQueueWithProperties`.
+
+### The Execution Model
+
+OpenCL executes code in a data-parallel fashion:
+
+- **Kernel** — A function written in OpenCL C (or compiled to SPIR-V) that runs
+  on the device. Marked with the `__kernel` qualifier.
+- **Work-item** — A single instance of a kernel invocation. Each work-item has
+  a unique global ID.
+- **Work-group** — A collection of work-items that share local memory and can
+  synchronize. Work-groups are scheduled independently.
+- **NDRange** — The total set of work-items, organized in 1D, 2D, or 3D. The
+  host specifies the global size and optionally the local (work-group) size when
+  calling `clEnqueueNDRangeKernel`.
+
+Work-items get their ID from built-in functions:
+
+```c
+get_global_id(dim)    // global index in dimension dim
+get_local_id(dim)     // index within the work-group
+get_global_size(dim)  // total number of work-items in dimension dim
+```
+
+### The Memory Model
+
+OpenCL defines four memory regions accessible from kernels:
+
+| Region | Qualifier | Scope | Notes |
+|--------|-----------|-------|-------|
+| Global | `__global` | All work-items | Main device memory, accessible by host via buffers |
+| Constant | `__constant` | All work-items | Read-only, cached |
+| Local | `__local` | Work-group | Shared within a work-group, fast |
+| Private | `__private` | Single work-item | Registers / stack, default for function locals |
+
+The host manages device memory through buffer objects (`cl_mem`), created with
+`clCreateBuffer`. Data is transferred via `clEnqueueWriteBuffer` /
+`clEnqueueReadBuffer` or at buffer creation time with `CL_MEM_COPY_HOST_PTR`.
+
+### The Programming Model
+
+**Kernel language**: OpenCL C (a subset of C99 with vector types and address
+space qualifiers). OpenCL 2.2+ also accepts SPIR-V as an intermediate language.
+
+**Host API**: A C API exposed through `<CL/cl.h>`. Functions follow the naming
+pattern `clVerbNoun` (`clCreateBuffer`, `clSetKernelArg`, etc.). Every function
+returns a `cl_int` error code.
+
+**Compilation flow**:
+
+1. At build time, kernel source (`.cl`) can be compiled to SPIR-V IL.
+2. At runtime, the host loads either SPIR-V IL (`clCreateProgramWithIL`) or
+   raw source (`clCreateProgramWithSource`).
+3. The program is built for the target device with `clBuildProgram`.
+4. Kernels are extracted with `clCreateKernel`.
+
+## Hardware Considerations
+
+OpenCL runs on a wide range of hardware:
+
+| Vendor | Support | Notes |
+|--------|---------|-------|
+| NVIDIA | OpenCL 1.2–3.0 | All GeForce / Quadro / Tesla GPUs |
+| AMD | OpenCL 1.2–2.0 | Radeon GPUs, ROCm stack |
+| Intel | OpenCL 1.2–3.0 | Integrated GPUs (Gen9+), Xeon Phi, oneAPI |
+| ARM | OpenCL 1.2–2.0 | Mali GPUs |
+| Qualcomm | OpenCL 2.0 | Adreno GPUs |
+
+The ICD (Installable Client Driver) loader dispatches API calls to the correct
+vendor driver. Install the vendor's driver package and verify with:
+
+```bash
+clinfo          # lists all platforms and devices
+```
+
+## OpenCL vs CUDA — A Comparison
+
+| Dimension | OpenCL | CUDA |
+|-----------|--------|------|
+| Vendor lock-in | None — runs on NVIDIA, AMD, Intel, ARM, etc. | NVIDIA GPUs only |
+| Kernel language | OpenCL C, SPIR-V IL | CUDA C++ (`.cu` files, `nvcc` compiler) |
+| Kernel compilation | Runtime (source or IL → device binary) | At runtime (NVCC / driver JIT) or ahead-of-time |
+| Memory management | Explicit `clCreateBuffer`, `clEnqueueRead/WriteBuffer` | `cudaMalloc`, `cudaMemcpy` |
+| API style | C API with `cl*` functions, manual error codes | C++ API with `cuda*` functions, error codes or exceptions |
+| Boilerplate | Moderate — context/queue setup, kernel arg setting | Lower — context is implicit, kernel launch syntax is `<<<>>>` |
+| Ecosystem | Khronos ecosystem, wider hardware reach | NVIDIA ecosystem (cuBLAS, cuDNN, Thrust, etc.) |
+| Performance | Portable; may not reach vendor-specific peaks on any single GPU | Tuned for NVIDIA hardware, often best performance on NVIDIA |
+| Debugging | Limited vendor tools | NVIDIA Nsight, cuda-memcheck |
+
+**When to choose OpenCL**: You need cross-vendor portability, or you're
+targeting non-NVIDIA hardware (AMD GPUs, Intel integrated GPUs, FPGAs).
+
+**When to choose CUDA**: You are targeting NVIDIA GPUs exclusively and want
+maximum performance, best tooling, and access to the CUDA ecosystem (cuBLAS,
+cuDNN, TensorRT, etc.).
+
+## How This Program Works (Step by Step)
+
+This program adds two float vectors `A` and `B` to produce `C`, where
+`C[i] = A[i] + B[i]`. It uses three source files:
+
+| File | Role |
+|------|------|
+| `main.cpp` | Host entry point — sets up data, runs kernel, validates results |
+| `opencl_runtime.cpp` | Platform → device → context → queue initialization |
+| `opencl_program.cpp` | Loads SPIR-V IL or OpenCL C source, builds the program |
+| `vector_add.cpp` | Creates buffers, sets kernel args, dispatches, reads back |
+| `vector_add_kernel.cl` | The GPU kernel — the actual vector add |
+
+### Step 1: Runtime initialization (`opencl_runtime.cpp`)
+
+`OpenClRuntime::Initialize()` sets up the four foundational objects in order:
+
+```cpp
+clGetPlatformIDs(1, &platform_, nullptr);
+clGetDeviceIDs(platform_, CL_DEVICE_TYPE_DEFAULT, 1, &device_, nullptr);
+context_ = clCreateContext(nullptr, 1, &device_, nullptr, nullptr, &err);
+queue_ = clCreateCommandQueueWithProperties(context_, device_, nullptr, &err);
+```
+
+This is the standard OpenCL bootstrap sequence: find a platform, get a device,
+create a context for that device, and create a command queue to submit work.
+
+### Step 2: Program loading (`opencl_program.cpp`)
+
+`OpenClProgram::InitializeFromEmbedded()` loads the kernel code. It tries
+SPIR-V IL first (faster, pre-compiled), then falls back to OpenCL C source:
+
+```cpp
+program_ = clCreateProgramWithIL(runtime.Context(), il, il_size, &err);
+// if that fails:
+program_ = clCreateProgramWithSource(runtime.Context(), 1, &src, &src_len, &err);
+// then build for the target device:
+clBuildProgram(program_, 1, &device, nullptr, nullptr, nullptr);
+```
+
+### Step 3: Execute the vector add (`vector_add.cpp`)
+
+`OpenClVectorAddProgram::Execute()` does the full compute cycle:
+
+**3a. Allocate device buffers and copy input data:**
+
+```cpp
+cl_mem d_a = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                            n * sizeof(float), host_ptr_a, &err);
+cl_mem d_b = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR,
+                            n * sizeof(float), host_ptr_b, &err);
+cl_mem d_c = clCreateBuffer(context, CL_MEM_WRITE_ONLY,
+                            n * sizeof(float), nullptr, &err);
+```
+
+`CL_MEM_COPY_HOST_PTR` copies data from the host at creation time, so no
+separate write call is needed.
+
+**3b. Create the kernel and set arguments:**
+
+```cpp
+cl_kernel kernel = clCreateKernel(program, "vector_add_kernel", &err);
+clSetKernelArg(kernel, 0, sizeof(cl_mem), &d_a);
+clSetKernelArg(kernel, 1, sizeof(cl_mem), &d_b);
+clSetKernelArg(kernel, 2, sizeof(cl_mem), &d_c);
+clSetKernelArg(kernel, 3, sizeof(int), &n);
+```
+
+Arguments are set by index — index 0 is `A`, 1 is `B`, 2 is `C`, 3 is `n`.
+
+**3c. Dispatch and read back:**
+
+```cpp
+size_t global = n;
+clEnqueueNDRangeKernel(queue, kernel, 1, nullptr, &global, nullptr, 0, nullptr, nullptr);
+clEnqueueReadBuffer(queue, d_c, CL_TRUE, 0, n * sizeof(float), c, 0, nullptr, nullptr);
+clFinish(queue);
+```
+
+`CL_TRUE` makes `clEnqueueReadBuffer` blocking — it waits for the kernel to
+finish before copying `d_c` into the host buffer `c`.
+
+**3d. Cleanup:**
+
+```cpp
+clReleaseKernel(kernel);
+clReleaseMemObject(d_a);
+clReleaseMemObject(d_b);
+clReleaseMemObject(d_c);
+```
+
+### Step 4: The kernel (`vector_add_kernel.cl`)
+
+```c
+__kernel void vector_add_kernel(__global const float* A,
+                                __global const float* B,
+                                __global float* C,
+                                const int n) {
+    int i = get_global_id(0);
+    if (i < n) {
+        C[i] = A[i] + B[i];
+    }
+}
+```
+
+Line by line:
+
+- `__kernel` — Marks this function as a GPU kernel.
+- `__global const float* A` — Pointer to global (device) memory, read-only.
+- `__global float* C` — Pointer to global memory, writable.
+- `const int n` — Scalar argument passed directly from the host (not a buffer).
+- `get_global_id(0)` — Returns this work-item's index in the first dimension.
+  The host enqueued an NDRange of size `n`, so each work-item gets a unique
+  `i` from 0 to `n-1`.
+- `if (i < n)` — Bounds check. This is necessary because the NDRange size may
+  be rounded up to a multiple of the work-group size. In this program the host
+  doesn't specify a work-group size, so the runtime picks one, and the global
+  size is exactly `n` — but the guard is good practice.
+
+### Step 5: Validation (`main.cpp`)
+
+Back on the host, `main.cpp` loops over the result and checks each element:
+
+```cpp
+for (int i = 0; i < n; ++i) {
+    const float want = h_a[i] + h_b[i];
+    if (std::abs(h_c[i] - want) > 1e-5F) {
+        std::cerr << "Mismatch at " << i << ": want " << want << " got " << h_c[i] << "\n";
+        return 1;
+    }
+}
+```
+
+---
+
 ## Build and run
 
 From repo root:

--- a/src/cpp_accelerator/cmd/hello-world-vulkan/README.md
+++ b/src/cpp_accelerator/cmd/hello-world-vulkan/README.md
@@ -3,6 +3,405 @@
 Minimal compute-shader example: add two float vectors on the GPU with Vulkan and Vulkan-Hpp.
 This sample is for learning, not production architecture.
 
+## What is Vulkan?
+
+Vulkan is a low-level graphics and compute API created by the Khronos Group,
+first released in 2016 as the successor to OpenGL. While Vulkan is best known
+for rendering, it has a full compute pipeline that lets you run arbitrary
+parallel workloads on the GPU — similar to CUDA or OpenCL, but with explicit
+control over every aspect of GPU operation.
+
+Key versions:
+
+| Version | Year | Highlights |
+|---------|------|------------|
+| 1.0 | 2016 | Initial release, compute + graphics |
+| 1.1 | 2018 | Subgroup operations, protected memory |
+| 1.2 | 2020 | Timeline semaphores, buffer device address |
+| 1.3 | 2022 | Dynamic rendering, inline uniform blocks |
+
+This example uses the C++ Vulkan-Hpp wrapper (`<vulkan/vulkan.hpp>`, `vk::`
+namespace) which provides RAII-friendly types and throws `vk::SystemError`
+exceptions on failure, reducing boilerplate compared to the C API.
+
+## Core Concepts You Need to Know
+
+### Instance and Physical Devices
+
+- **`vk::Instance`** — The connection between your application and the Vulkan
+  library. Created first, it loads the Vulkan driver. You specify enabled
+  layers and extensions at instance creation.
+- **`vk::PhysicalDevice`** — Represents a physical GPU (or software renderer)
+  on the system. Enumerated from the instance with `enumeratePhysicalDevices()`.
+  Each physical device has properties (name, API version) and queue families.
+
+### Logical Devices and Queues
+
+- **`vk::Device`** — A logical device created from a physical device. This is
+  your primary interface for creating GPU resources (buffers, pipelines, etc.)
+  and submitting work.
+- **Queue families** — Each physical device exposes one or more queue families.
+  Each family supports a set of operations: compute, graphics, transfer, etc.
+  You query family capabilities with `getQueueFamilyProperties()` and look for
+  the `eCompute` flag.
+- **`vk::Queue`** — Obtained from the logical device. You submit command buffers
+  to a queue for execution. A compute queue can run compute shaders.
+
+### Command Buffers and Command Pools
+
+- **`vk::CommandPool`** — Allocates command buffer memory. Created per queue
+  family. Commands pools are not thread-safe unless you use the
+  `eResetCommandBuffer` flag.
+- **`vk::CommandBuffer`** — Records GPU commands (bind pipeline, bind
+  descriptors, dispatch, etc.). Recorded once, then submitted to a queue.
+  This example uses `eOneTimeSubmit` since the command buffer is used only
+  once per execute call.
+
+### Pipelines and Shader Modules
+
+- **`vk::ShaderModule`** — Wraps compiled SPIR-V bytecode. Created from a
+  `.spv` file (or embedded bytes). The module contains one or more entry
+  points (functions).
+- **`vk::ComputePipeline`** — A pipeline object that binds a shader module
+  entry point to a pipeline layout. For compute, there is a single shader
+  stage — no vertex/fragment stages like in graphics.
+- **`vk::PipelineLayout`** — Defines the interface between the shader and
+  the host: descriptor set layouts (for buffer bindings) and push constant
+  ranges (for small values passed directly in the command buffer).
+
+### Descriptors
+
+Descriptors are how the shader accesses buffer and image resources:
+
+- **`vk::DescriptorSetLayout`** — Declares what resources the shader expects
+  (binding number, type, shader stage). Think of it as a "schema."
+- **`vk::DescriptorPool`** — Allocates descriptor sets. You specify how many
+  descriptors of each type the pool can hold.
+- **`vk::DescriptorSet`** — A concrete binding of descriptors matching a
+  layout. You write buffer handles into descriptor sets, then bind the set
+  during command buffer recording.
+
+### Memory Management
+
+Vulkan exposes fine-grained control over GPU memory:
+
+- **`vk::Buffer`** — A handle representing a region of GPU-accessible memory
+  with a specific usage (storage buffer, uniform buffer, etc.).
+- **`vk::DeviceMemory`** — Actual backing memory allocated from the GPU.
+  Buffers do not have memory until you explicitly allocate and bind it.
+- **Memory types** — Each physical device has multiple memory types with
+  different properties:
+  - `eHostVisible` — CPU can map and access this memory.
+  - `eHostCoherent` — No need to flush/invalidate caches between CPU and GPU.
+  - `eDeviceLocal` — GPU-local memory, fastest for GPU access.
+
+The host uploads data by calling `mapMemory`, copying bytes with `memcpy`,
+then `unmapMemory`. Reading back works the same way.
+
+### Synchronization
+
+- **`vk::Fence`** — A host-GPU synchronization primitive. The host submits a
+  command buffer with a fence, then calls `waitForFences` to block until the
+  GPU finishes. This example uses a fence to wait for kernel completion before
+  reading back results.
+
+### SPIR-V and GLSL
+
+Vulkan shaders are distributed as SPIR-V bytecode, not GLSL source. The typical
+workflow:
+
+1. Write GLSL (`.comp` for compute shaders).
+2. Compile to SPIR-V with `glslc` (part of the Vulkan SDK).
+3. Embed the `.spv` bytes into the binary at build time.
+
+GLSL compute shader structure:
+
+```glsl
+#version 450
+layout(local_size_x = 64) in;
+// ... buffer bindings and push constants ...
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    // ... compute ...
+}
+```
+
+- `#version 450` — GLSL version (SPIR-V 1.0).
+- `local_size_x = 64` — Each work-group has 64 invocations (threads).
+- `gl_GlobalInvocationID.x` — Global thread index, equivalent to CUDA's
+  `threadIdx.x + blockIdx.x * blockDim.x`.
+
+## Hardware Considerations
+
+Vulkan requires a relatively modern GPU:
+
+| Vendor | Minimum | Notes |
+|--------|---------|-------|
+| NVIDIA | Kepler (GTX 600 series) | Full Vulkan 1.3 support on Turing+ |
+| AMD | GCN (Radeon HD 7700+) | Full support on RDNA+ |
+| Intel | Haswell (HD 4400+) | Full support on Xe GPUs |
+| ARM | Mali Midgard+ | Common on Android devices |
+
+On Linux, Mesa provides open-source Vulkan drivers for AMD (RADV), Intel
+(ANV), and others. Verify your setup with:
+
+```bash
+vulkaninfo       # lists physical devices and capabilities
+```
+
+## Vulkan Compute vs CUDA — A Comparison
+
+| Dimension | Vulkan Compute | CUDA |
+|-----------|----------------|------|
+| Vendor lock-in | None — runs on NVIDIA, AMD, Intel, ARM, Qualcomm | NVIDIA GPUs only |
+| Boilerplate | Very high — descriptors, pipelines, memory allocation all explicit | Low — `cudaMalloc`, kernel launch with `<<<>>>` syntax |
+| Explicitness | Everything is explicit: memory types, barriers, pipeline creation | Implicit context management, automatic memory transfers |
+| Memory control | Fine-grained — choose memory type per allocation | Abstracted — `cudaMalloc` picks the right type |
+| Kernel language | GLSL/HLSL → SPIR-V | CUDA C++ (`.cu`, `nvcc`) |
+| Ecosystem | Primarily graphics-oriented; compute ecosystem growing | Massive — cuBLAS, cuDNN, TensorRT, Thrust, Nsight |
+| Debugging | RenderDoc, Vulkan validation layers | NVIDIA Nsight, cuda-memcheck |
+| Portability | Runs on any Vulkan-capable GPU, including mobile | NVIDIA only |
+| Performance | Portable but verbose; may leave performance on the table without tuning | Best on NVIDIA hardware, heavily optimized toolchain |
+
+**When to choose Vulkan Compute**: You need cross-vendor GPU compute, your
+project already uses Vulkan for rendering, or you're targeting mobile/embedded
+GPUs.
+
+**When to choose CUDA**: You are targeting NVIDIA GPUs, want the best
+performance with the least boilerplate, and need access to the CUDA library
+ecosystem.
+
+## How This Program Works (Step by Step)
+
+This program adds two float vectors `A` and `B` to produce `C`, where
+`C[i] = A[i] + B[i]`. It uses three source files:
+
+| File | Role |
+|------|------|
+| `main.cpp` | Host entry point — sets up data, runs kernel, validates results |
+| `vulkan_runtime.cpp` | Instance → physical device → logical device → queue setup |
+| `vulkan_program.cpp` | Loads embedded SPIR-V into a shader module |
+| `vector_add.cpp` | Full compute pipeline — descriptors, pipeline, buffers, dispatch |
+| `vector_add_kernel.comp` | The GLSL compute shader |
+
+### Step 1: Runtime initialization (`vulkan_runtime.cpp`)
+
+`VulkanRuntime::Initialize()` creates the Vulkan connection and device:
+
+```cpp
+instance_ = vk::createInstance(instance_ci);
+auto physical_devices = instance_.enumeratePhysicalDevices();
+```
+
+Then it searches for a queue family that supports compute:
+
+```cpp
+for (uint32_t j = 0; j < queue_families.size(); ++j) {
+    if (queue_families[j].queueFlags & vk::QueueFlagBits::eCompute) {
+        compute_queue_family_index_ = j;
+        physical_device_ = physical_devices[i];
+    }
+}
+```
+
+Finally it creates the logical device and retrieves the queue:
+
+```cpp
+device_ = physical_device_.createDevice(device_ci);
+queue_ = device_.getQueue(compute_queue_family_index_, 0);
+```
+
+### Step 2: Shader module loading (`vulkan_program.cpp`)
+
+`VulkanProgram::InitializeFromEmbedded()` wraps the embedded SPIR-V bytes
+into a shader module:
+
+```cpp
+vk::ShaderModuleCreateInfo ci({}, size_bytes,
+                              reinterpret_cast<const uint32_t*>(spirv));
+shader_module_ = device_.createShaderModule(ci);
+```
+
+### Step 3: Execute the vector add (`vector_add.cpp`)
+
+`VulkanVectorAddProgram::Execute()` is the most complex part. It creates all
+Vulkan objects needed for a single compute dispatch, then cleans them up.
+
+**3a. Descriptor set layout:**
+
+Defines three storage buffer bindings (A, B, C) visible to the compute stage:
+
+```cpp
+std::vector<vk::DescriptorSetLayoutBinding> bindings = {
+    {0, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute, nullptr},
+    {1, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute, nullptr},
+    {2, vk::DescriptorType::eStorageBuffer, 1, vk::ShaderStageFlagBits::eCompute, nullptr},
+};
+descriptor_set_layout = device.createDescriptorSetLayout(
+    vk::DescriptorSetLayoutCreateInfo({}, bindings));
+```
+
+**3b. Pipeline layout and compute pipeline:**
+
+The pipeline layout connects descriptor sets and push constants to the shader:
+
+```cpp
+vk::PushConstantRange push_range(vk::ShaderStageFlagBits::eCompute, 0, sizeof(uint32_t));
+pipeline_layout = device.createPipelineLayout(
+    vk::PipelineLayoutCreateInfo({}, 1, &descriptor_set_layout, 1, &push_range));
+```
+
+Then the compute pipeline is created — binding the shader module entry point
+to the pipeline layout:
+
+```cpp
+auto rv = device.createComputePipeline(
+    nullptr, vk::ComputePipelineCreateInfo({}, shader_stage, pipeline_layout));
+```
+
+**3c. Descriptor pool and descriptor set:**
+
+Allocate a descriptor set from a pool, then write buffer handles into it:
+
+```cpp
+descriptor_sets = device.allocateDescriptorSets(
+    vk::DescriptorSetAllocateInfo(descriptor_pool, 1, &descriptor_set_layout));
+```
+
+**3d. Buffer creation and memory allocation:**
+
+For each buffer, the code creates a `vk::Buffer`, queries its memory
+requirements, finds a suitable memory type (host-visible + host-coherent),
+allocates `vk::DeviceMemory`, and binds it:
+
+```cpp
+buf_a = device.createBuffer(vk::BufferCreateInfo(
+    {}, buf_size, vk::BufferUsageFlagBits::eStorageBuffer, vk::SharingMode::eExclusive));
+auto reqs = device.getBufferMemoryRequirements(buf);
+uint32_t type_idx = find_memory_type(reqs);  // host-visible + host-coherent
+vk::DeviceMemory mem = device.allocateMemory(vk::MemoryAllocateInfo(reqs.size, type_idx));
+device.bindBufferMemory(buf, mem, 0);
+```
+
+**3e. Upload data:**
+
+Map device memory, copy host data in, unmap:
+
+```cpp
+void* mapped = device.mapMemory(mem, 0, size);
+std::memcpy(mapped, data, size);
+device.unmapMemory(mem);
+```
+
+**3f. Update descriptor sets:**
+
+Connect the buffer handles to the descriptor set bindings:
+
+```cpp
+vk::DescriptorBufferInfo buf_info_a(buf_a, 0, buf_size);
+vk::WriteDescriptorSet write{descriptor_sets[0], 0, 0, 1,
+    vk::DescriptorType::eStorageBuffer, nullptr, &buf_info_a};
+device.updateDescriptorSets(writes.size(), writes.data(), 0, nullptr);
+```
+
+**3g. Record command buffer:**
+
+Create a command pool and buffer, then record: bind pipeline, bind descriptor
+sets, push constants, dispatch:
+
+```cpp
+cmd_buffers[0].begin(vk::CommandBufferBeginInfo(vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+cmd_buffers[0].bindPipeline(vk::PipelineBindPoint::eCompute, compute_pipeline);
+cmd_buffers[0].bindDescriptorSets(vk::PipelineBindPoint::eCompute, pipeline_layout, 0, 1,
+                                  descriptor_sets.data(), 0, nullptr);
+cmd_buffers[0].pushConstants(pipeline_layout, vk::ShaderStageFlagBits::eCompute, 0,
+                             sizeof(uint32_t), &n_u32);
+uint32_t group_count = (n + 63U) / 64U;
+cmd_buffers[0].dispatch(group_count, 1, 1);
+cmd_buffers[0].end();
+```
+
+The dispatch math: the shader uses `local_size_x = 64`, so each work-group
+processes 64 elements. The host dispatches `(n + 63) / 64` groups to cover all
+`n` elements (with potential overshoot, guarded in the shader).
+
+**3h. Submit and wait:**
+
+```cpp
+vk::Fence fence = device.createFence(vk::FenceCreateInfo());
+runtime_.Queue().submit(submit_info, fence);
+device.waitForFences(fence, vk::True, UINT64_MAX);
+```
+
+**3i. Read back results:**
+
+```cpp
+void* mapped_c = device.mapMemory(mem_c, 0, buf_size);
+std::memcpy(c, mapped_c, buf_size);
+device.unmapMemory(mem_c);
+```
+
+**3j. Cleanup:**
+
+All Vulkan objects created in `Execute()` are destroyed by the `cleanup`
+lambda — descriptor set layout, pipeline layout, pipeline, descriptor pool,
+buffers, device memory, command pool, and fence.
+
+### Step 4: The compute shader (`vector_add_kernel.comp`)
+
+```glsl
+#version 450
+
+layout(local_size_x = 64) in;
+
+layout(binding = 0) buffer BufferA { float data_A[]; };
+layout(binding = 1) buffer BufferB { float data_B[]; };
+layout(binding = 2) buffer BufferC { float data_C[]; };
+
+layout(push_constant) uniform PushConstants { uint n; };
+
+void main() {
+    uint i = gl_GlobalInvocationID.x;
+    if (i < n) {
+        data_C[i] = data_A[i] + data_B[i];
+    }
+}
+```
+
+Line by line:
+
+- `#version 450` — GLSL version targeting SPIR-V 1.0 / Vulkan 1.0.
+- `layout(local_size_x = 64) in` — Each work-group has 64 invocations
+  (threads). The host must dispatch enough groups to cover all elements.
+- `buffer BufferA { float data_A[]; }` — SSBO (Shader Storage Buffer Object)
+  bound at descriptor set binding 0. Runtime-sized arrays (`data_A[]`) are
+  valid in SSBOs.
+- `push_constant uniform PushConstants { uint n; }` — A small value (`n`)
+  passed directly in the command buffer via `pushConstants`, avoiding the need
+  for a separate uniform buffer.
+- `gl_GlobalInvocationID.x` — Global thread index across all dispatched
+  work-groups. Equivalent to `get_global_id(0)` in OpenCL or
+  `threadIdx.x + blockIdx.x * blockDim.x` in CUDA.
+- `if (i < n)` — Bounds guard. Since `group_count = (n + 63) / 64`, the last
+  group may spawn invocations beyond `n`. This guard prevents out-of-bounds
+  writes.
+
+### Step 5: Validation (`main.cpp`)
+
+Back on the host, `main.cpp` loops over all `n` elements and checks each one:
+
+```cpp
+for (int i = 0; i < kN; ++i) {
+    float want = h_a[i] + h_b[i];
+    if (std::abs(h_c[i] - want) > 1e-5F) {
+        std::cerr << "Mismatch at " << i << ": want " << want << " got " << h_c[i] << "\n";
+        return 1;
+    }
+}
+```
+
+---
+
 ## Build and run
 
 From repo root:


### PR DESCRIPTION
- Added comprehensive sections on OpenCL and Vulkan, including their definitions, core concepts, hardware considerations, and comparisons with CUDA.
- Enhanced the documentation to provide a clearer understanding of the programming models, memory management, and execution models for both APIs.